### PR TITLE
Extensions update

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,6 +9,7 @@ disabled_rules:
   - explicit_type_interface
   - extension_access_modifier
   - fatal_error_message
+  - file_name # doesn't work as it should
   - force_cast
   - force_unwrapping
   - function_default_parameter_at_end
@@ -31,6 +32,7 @@ disabled_rules:
   - trailing_closure
   - unused_closure_parameter
   - vertical_whitespace_opening_braces # should ignore braces after type declarations
+
 
 opt_in_rules:
   - anyobject_protocol
@@ -337,7 +339,7 @@ file_length:
 file_name:
   severity: error
   prefix_pattern: ''
-  suffix_pattern: 'Extensions?|\\+.*'
+  suffix_pattern: '(([A-Z][A-z]+)Extension)?'
 
 first_where:
   severity: error
@@ -486,8 +488,8 @@ nesting:
     warning: 1
     error: 1
   statement_level:
-    warning: 2
-    error: 2
+    warning: 3
+    error: 3
 
 no_extension_access_modifier:
   severity: error

--- a/AurorKit.podspec
+++ b/AurorKit.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |spec|
   spec.name = "AurorKit"
   spec.version = "0.0.3"
   spec.summary = "Swift extensions and tools"
-  
+
   spec.homepage = "https://github.com/almazrafi/AurorKit"
   spec.license = { :type => 'MIT', :file => 'LICENSE' }
   spec.author = { "Almaz Ibragimov" => "almazrafi@gmail.com" }
@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
 
   spec.swift_version = '4.2'
   spec.requires_arc = true
-  
+
   spec.ios.frameworks = 'Foundation', 'CoreGraphics', 'UIKit'
   spec.ios.deployment_target = "10.0"
 
@@ -31,13 +31,19 @@ Pod::Spec.new do |spec|
       "AurorKit/Extensions/UIColorExtension.swift",
       "AurorKit/Extensions/UIEdgeInsetsExtension.swift",
       "AurorKit/Extensions/UIImageExtension.swift",
+      "AurorKit/Extensions/UIViewBorderExtension.swift",
+      "AurorKit/Extensions/UIViewControllerExtension.swift",
       "AurorKit/Extensions/UIViewExtension.swift",
+      "AurorKit/Extensions/UIViewShadowExtension.swift",
       "AurorKit/Extensions/UIWindowExtension.swift"
     ]
 
     extensions.watchos.exclude_files = [
       "AurorKit/Extensions/NSLayoutConstraintExtension.swift",
+      "AurorKit/Extensions/UIViewBorderExtension.swift",
+      "AurorKit/Extensions/UIViewControllerExtension.swift",
       "AurorKit/Extensions/UIViewExtension.swift",
+      "AurorKit/Extensions/UIViewShadowExtension.swift",
       "AurorKit/Extensions/UIWindowExtension.swift"
     ]
   end

--- a/AurorKit.xcodeproj/project.pbxproj
+++ b/AurorKit.xcodeproj/project.pbxproj
@@ -109,12 +109,11 @@
 		C2B8D8E82210EBF100C67D84 /* UIViewShadowExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B8D8DF2210D71400C67D84 /* UIViewShadowExtension.swift */; };
 		C2E865EE22136CAD002DD5D4 /* UIViewBorderExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E865ED22136CAD002DD5D4 /* UIViewBorderExtensionTests.swift */; };
 		C2E865F12213705B002DD5D4 /* UIViewShadowExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E865F02213705B002DD5D4 /* UIViewShadowExtensionTests.swift */; };
-		C2E865F22213705B002DD5D4 /* UIViewShadowExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E865F02213705B002DD5D4 /* UIViewShadowExtensionTests.swift */; };
 		C2E865F422137071002DD5D4 /* UIViewControllerExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E865F322137071002DD5D4 /* UIViewControllerExtensionTests.swift */; };
-		C2E865F522137071002DD5D4 /* UIViewControllerExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E865F322137071002DD5D4 /* UIViewControllerExtensionTests.swift */; };
 		C2E865F722138022002DD5D4 /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E865F622138022002DD5D4 /* Matchers.swift */; };
 		C2E865F9221384E5002DD5D4 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = C2E865F8221384E5002DD5D4 /* .swiftlint.yml */; };
 		C2E865FB22138DB0002DD5D4 /* ComparableExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E865FA22138DB0002DD5D4 /* ComparableExtensionTests.swift */; };
+		C2E865FC22139EB0002DD5D4 /* ComparableExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E865FA22138DB0002DD5D4 /* ComparableExtensionTests.swift */; };
 		C6A1CA08751D7C17FC4D3CBA /* Pods_AurorKit_Tests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02DF386D7694E2F925587C3C /* Pods_AurorKit_Tests_iOS.framework */; };
 		F4A633FEA053DC2DC949EC22 /* Pods_AurorKit_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBB4E7007CB44FF38238EC0B /* Pods_AurorKit_macOS.framework */; };
 /* End PBXBuildFile section */
@@ -985,9 +984,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C2E865F22213705B002DD5D4 /* UIViewShadowExtensionTests.swift in Sources */,
 				C0A6037621F682D3009EC42C /* Tests.swift in Sources */,
-				C2E865F522137071002DD5D4 /* UIViewControllerExtensionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1026,6 +1023,7 @@
 				C0AE17AB21F679EB0070DD72 /* ContiguousArrayExtensionTests.swift in Sources */,
 				C0AE17A721F679EB0070DD72 /* CGPointExtensionTests.swift in Sources */,
 				C0A6037721F682D4009EC42C /* Tests.swift in Sources */,
+				C2E865FC22139EB0002DD5D4 /* ComparableExtensionTests.swift in Sources */,
 				C0AE17AD21F679EB0070DD72 /* FloatingPointExtensionTests.swift in Sources */,
 				C0AE17A621F679EB0070DD72 /* ArrayExtensionTests.swift in Sources */,
 			);

--- a/AurorKit.xcodeproj/project.pbxproj
+++ b/AurorKit.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		C0252D5521F3A35E00F41A26 /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0252D5421F3A35E00F41A26 /* ArrayExtension.swift */; };
 		C0252D5721F3A5AC00F41A26 /* DataExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0252D5621F3A5AC00F41A26 /* DataExtension.swift */; };
 		C0252D5C21F3BDF300F41A26 /* DataExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0252D5821F3A9D600F41A26 /* DataExtensionTests.swift */; };
-		C0252D5E21F3BEAA00F41A26 /* FloatingPointExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0252D5D21F3BEAA00F41A26 /* FloatingPointExtension.swift */; };
 		C0252D6021F3BEED00F41A26 /* FloatingPointExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0252D5F21F3BEED00F41A26 /* FloatingPointExtensionTests.swift */; };
 		C0252D6421F3D0A300F41A26 /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0252D6321F3D0A300F41A26 /* StringExtensionTests.swift */; };
 		C0252D6521F3D0A900F41A26 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0252D6121F3C37B00F41A26 /* StringExtension.swift */; };
@@ -98,6 +97,24 @@
 		C0AFE92021F4F63500A7005D /* UIColorExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0AFE91F21F4F63500A7005D /* UIColorExtensionTests.swift */; };
 		C0E9FD7721F253A8009C453F /* AurorKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0E9FD6E21F253A7009C453F /* AurorKit.framework */; };
 		C0E9FD7E21F253A8009C453F /* AurorKit.h in Headers */ = {isa = PBXBuildFile; fileRef = C0E9FD7021F253A8009C453F /* AurorKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C2B8D8DB22108C3600C67D84 /* FloatingPointExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0252D5D21F3BEAA00F41A26 /* FloatingPointExtension.swift */; };
+		C2B8D8DD2210D62100C67D84 /* UIViewBorderExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B8D8DC2210D62100C67D84 /* UIViewBorderExtension.swift */; };
+		C2B8D8DE2210D63F00C67D84 /* UIViewBorderExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B8D8DC2210D62100C67D84 /* UIViewBorderExtension.swift */; };
+		C2B8D8E02210D71400C67D84 /* UIViewShadowExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B8D8DF2210D71400C67D84 /* UIViewShadowExtension.swift */; };
+		C2B8D8E22210EB6100C67D84 /* ComparableExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B8D8E12210EB6100C67D84 /* ComparableExtension.swift */; };
+		C2B8D8E32210EBD100C67D84 /* ComparableExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B8D8E12210EB6100C67D84 /* ComparableExtension.swift */; };
+		C2B8D8E42210EBD200C67D84 /* ComparableExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B8D8E12210EB6100C67D84 /* ComparableExtension.swift */; };
+		C2B8D8E62210EBEB00C67D84 /* UIViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B8D8E52210EBEB00C67D84 /* UIViewControllerExtension.swift */; };
+		C2B8D8E72210EBEB00C67D84 /* UIViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B8D8E52210EBEB00C67D84 /* UIViewControllerExtension.swift */; };
+		C2B8D8E82210EBF100C67D84 /* UIViewShadowExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B8D8DF2210D71400C67D84 /* UIViewShadowExtension.swift */; };
+		C2E865EE22136CAD002DD5D4 /* UIViewBorderExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E865ED22136CAD002DD5D4 /* UIViewBorderExtensionTests.swift */; };
+		C2E865F12213705B002DD5D4 /* UIViewShadowExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E865F02213705B002DD5D4 /* UIViewShadowExtensionTests.swift */; };
+		C2E865F22213705B002DD5D4 /* UIViewShadowExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E865F02213705B002DD5D4 /* UIViewShadowExtensionTests.swift */; };
+		C2E865F422137071002DD5D4 /* UIViewControllerExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E865F322137071002DD5D4 /* UIViewControllerExtensionTests.swift */; };
+		C2E865F522137071002DD5D4 /* UIViewControllerExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E865F322137071002DD5D4 /* UIViewControllerExtensionTests.swift */; };
+		C2E865F722138022002DD5D4 /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E865F622138022002DD5D4 /* Matchers.swift */; };
+		C2E865F9221384E5002DD5D4 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = C2E865F8221384E5002DD5D4 /* .swiftlint.yml */; };
+		C2E865FB22138DB0002DD5D4 /* ComparableExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E865FA22138DB0002DD5D4 /* ComparableExtensionTests.swift */; };
 		C6A1CA08751D7C17FC4D3CBA /* Pods_AurorKit_Tests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02DF386D7694E2F925587C3C /* Pods_AurorKit_Tests_iOS.framework */; };
 		F4A633FEA053DC2DC949EC22 /* Pods_AurorKit_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DBB4E7007CB44FF38238EC0B /* Pods_AurorKit_macOS.framework */; };
 /* End PBXBuildFile section */
@@ -197,10 +214,20 @@
 		C0E9FD7121F253A8009C453F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C0E9FD7621F253A8009C453F /* AurorKit Tests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AurorKit Tests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C294FBE62203D98B00ECCB4E /* Bootstrap.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = Bootstrap.sh; sourceTree = "<group>"; };
+		C2B8D8DC2210D62100C67D84 /* UIViewBorderExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewBorderExtension.swift; sourceTree = "<group>"; };
+		C2B8D8DF2210D71400C67D84 /* UIViewShadowExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewShadowExtension.swift; sourceTree = "<group>"; };
+		C2B8D8E12210EB6100C67D84 /* ComparableExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComparableExtension.swift; sourceTree = "<group>"; };
+		C2B8D8E52210EBEB00C67D84 /* UIViewControllerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerExtension.swift; sourceTree = "<group>"; };
 		C2CD9CEA22103DF100EBB05B /* .codecov.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .codecov.yml; sourceTree = "<group>"; };
 		C2CD9CEB22103DF100EBB05B /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		C2CD9CEC22103DF100EBB05B /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .swiftlint.yml; sourceTree = "<group>"; };
 		C2CD9CED22103DF100EBB05B /* .travis.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .travis.yml; sourceTree = "<group>"; };
+		C2E865ED22136CAD002DD5D4 /* UIViewBorderExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewBorderExtensionTests.swift; sourceTree = "<group>"; };
+		C2E865F02213705B002DD5D4 /* UIViewShadowExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewShadowExtensionTests.swift; sourceTree = "<group>"; };
+		C2E865F322137071002DD5D4 /* UIViewControllerExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerExtensionTests.swift; sourceTree = "<group>"; };
+		C2E865F622138022002DD5D4 /* Matchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Matchers.swift; sourceTree = "<group>"; };
+		C2E865F8221384E5002DD5D4 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .swiftlint.yml; sourceTree = "<group>"; };
+		C2E865FA22138DB0002DD5D4 /* ComparableExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComparableExtensionTests.swift; sourceTree = "<group>"; };
 		D023EA186ECF76C7D5EC6690 /* Pods-Tools Tests iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tools Tests iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tools Tests iOS/Pods-Tools Tests iOS.release.xcconfig"; sourceTree = "<group>"; };
 		D36F6A818A8A1DA9E5CE5E34 /* Pods-AurorKit macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AurorKit macOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-AurorKit macOS/Pods-AurorKit macOS.release.xcconfig"; sourceTree = "<group>"; };
 		D6414EEBC854146F383353DF /* Pods-AurorKit Tests iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AurorKit Tests iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-AurorKit Tests iOS/Pods-AurorKit Tests iOS.release.xcconfig"; sourceTree = "<group>"; };
@@ -276,6 +303,7 @@
 				C05A655121F35AA70038EC55 /* CGRectExtension.swift */,
 				C05A655321F35AF80038EC55 /* CGSizeExtension.swift */,
 				C05A653F21F343C30038EC55 /* CollectionExtension.swift */,
+				C2B8D8E12210EB6100C67D84 /* ComparableExtension.swift */,
 				C05A654521F353DA0038EC55 /* ContiguousArrayExtension.swift */,
 				C0252D5621F3A5AC00F41A26 /* DataExtension.swift */,
 				C0252D5D21F3BEAA00F41A26 /* FloatingPointExtension.swift */,
@@ -285,6 +313,9 @@
 				C0AFE91D21F4F29600A7005D /* UIColorExtension.swift */,
 				C0252D7221F3E2D800F41A26 /* UIEdgeInsetsExtension.swift */,
 				C0252D7721F3E43F00F41A26 /* UIImageExtension.swift */,
+				C2B8D8DC2210D62100C67D84 /* UIViewBorderExtension.swift */,
+				C2B8D8E52210EBEB00C67D84 /* UIViewControllerExtension.swift */,
+				C2B8D8DF2210D71400C67D84 /* UIViewShadowExtension.swift */,
 				C0336CE821F4B293006A182C /* UIViewExtension.swift */,
 				C0336CEE21F4B955006A182C /* UIWindowExtension.swift */,
 			);
@@ -299,6 +330,7 @@
 				C05A655821F3686C0038EC55 /* CGRectExtensionTests.swift */,
 				C05A655521F35D220038EC55 /* CGSizeExtensionTests.swift */,
 				C05A655B21F392DB0038EC55 /* CollectionExtensionTests.swift */,
+				C2E865FA22138DB0002DD5D4 /* ComparableExtensionTests.swift */,
 				C05A656021F399DE0038EC55 /* ContiguousArrayExtensionTests.swift */,
 				C0252D5821F3A9D600F41A26 /* DataExtensionTests.swift */,
 				C0252D5F21F3BEED00F41A26 /* FloatingPointExtensionTests.swift */,
@@ -308,7 +340,10 @@
 				C0AFE91F21F4F63500A7005D /* UIColorExtensionTests.swift */,
 				C0252D7421F3E33000F41A26 /* UIEdgeInsetsExtensionTests.swift */,
 				C0252D7921F3E4F200F41A26 /* UIImageExtensionTests.swift */,
+				C2E865ED22136CAD002DD5D4 /* UIViewBorderExtensionTests.swift */,
+				C2E865F322137071002DD5D4 /* UIViewControllerExtensionTests.swift */,
 				C0336CEA21F4B2D9006A182C /* UIViewExtensionTests.swift */,
+				C2E865F02213705B002DD5D4 /* UIViewShadowExtensionTests.swift */,
 				C0336CF021F4B9F2006A182C /* UIWindowExtensionTests.swift */,
 			);
 			path = Extensions;
@@ -371,7 +406,9 @@
 			children = (
 				C0E9FD6221F2496A009C453F /* Events */,
 				C05A653C21F3420E0038EC55 /* Extensions */,
+				C2E865F8221384E5002DD5D4 /* .swiftlint.yml */,
 				C0A94B2721F2056400FC4146 /* Info.plist */,
+				C2E865F622138022002DD5D4 /* Matchers.swift */,
 				C0A6037221F6825C009EC42C /* Tests.swift */,
 			);
 			path = AurorKitTests;
@@ -488,7 +525,6 @@
 				C0A6036321F680B9009EC42C /* Sources */,
 				C0A6036421F680B9009EC42C /* Frameworks */,
 				C0A6036521F680B9009EC42C /* Resources */,
-				C2DF3E062200FCBD00C6ACB1 /* SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -529,7 +565,6 @@
 				C0AE179521F6793A0070DD72 /* Frameworks */,
 				C0AE179621F6793A0070DD72 /* Resources */,
 				E8C4476F852862F633685735 /* [CP] Embed Pods Frameworks */,
-				C2DF3E012200FC5200C6ACB1 /* SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -570,7 +605,6 @@
 				C0E9FD7321F253A8009C453F /* Frameworks */,
 				C0E9FD7421F253A8009C453F /* Resources */,
 				9292AE8A60A5FD1CEAE83957 /* [CP] Embed Pods Frameworks */,
-				C2DF3E052200FCAD00C6ACB1 /* SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -674,6 +708,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C2E865F9221384E5002DD5D4 /* .swiftlint.yml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -748,24 +783,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C2DF3E012200FC5200C6ACB1 /* SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = SwiftLint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [ -z \"$CI\" ]; then\n  if which swiftlint >/dev/null; then\n    swiftlint\n  else\n    echo \"error: SwiftLint does not exist, download it from https://github.com/realm/SwiftLint\"\n    exit 1\n  fi\nfi\n";
-		};
 		C2DF3E022200FC8500C6ACB1 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -782,7 +799,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ -z \"$CI\" ]; then\n  if which swiftlint >/dev/null; then\n    swiftlint\n  else\n    echo \"error: SwiftLint does not exist, download it from https://github.com/realm/SwiftLint\"\n    exit 1\n  fi\nfi\n";
+			shellScript = "if [ -z \"$CI\" ]; then\n  if which swiftlint >/dev/null; then\n    swiftlint --no-cache\n  else\n    echo \"error: SwiftLint does not exist, download it from https://github.com/realm/SwiftLint\"\n    exit 1\n  fi\nfi\n";
 		};
 		C2DF3E032200FC9200C6ACB1 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -800,7 +817,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ -z \"$CI\" ]; then\n  if which swiftlint >/dev/null; then\n    swiftlint\n  else\n    echo \"error: SwiftLint does not exist, download it from https://github.com/realm/SwiftLint\"\n    exit 1\n  fi\nfi\n";
+			shellScript = "if [ -z \"$CI\" ]; then\n  if which swiftlint >/dev/null; then\n    swiftlint --no-cache\n  else\n    echo \"error: SwiftLint does not exist, download it from https://github.com/realm/SwiftLint\"\n    exit 1\n  fi\nfi\n";
 		};
 		C2DF3E042200FC9D00C6ACB1 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -818,43 +835,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ -z \"$CI\" ]; then\n  if which swiftlint >/dev/null; then\n    swiftlint\n  else\n    echo \"error: SwiftLint does not exist, download it from https://github.com/realm/SwiftLint\"\n    exit 1\n  fi\nfi\n";
-		};
-		C2DF3E052200FCAD00C6ACB1 /* SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = SwiftLint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [ -z \"$CI\" ]; then\n  if which swiftlint >/dev/null; then\n    swiftlint\n  else\n    echo \"error: SwiftLint does not exist, download it from https://github.com/realm/SwiftLint\"\n    exit 1\n  fi\nfi\n";
-		};
-		C2DF3E062200FCBD00C6ACB1 /* SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = SwiftLint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [ -z \"$CI\" ]; then\n  if which swiftlint >/dev/null; then\n    swiftlint\n  else\n    echo \"error: SwiftLint does not exist, download it from https://github.com/realm/SwiftLint\"\n    exit 1\n  fi\nfi\n";
+			shellScript = "if [ -z \"$CI\" ]; then\n  if which swiftlint >/dev/null; then\n    swiftlint --no-cache\n  else\n    echo \"error: SwiftLint does not exist, download it from https://github.com/realm/SwiftLint\"\n    exit 1\n  fi\nfi\n";
 		};
 		D0847FFCA128A5B9E4BDCF92 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -978,14 +959,18 @@
 				C080D10021F66C64003FBCF4 /* CGRectExtension.swift in Sources */,
 				C080D10A21F66C77003FBCF4 /* UIEdgeInsetsExtension.swift in Sources */,
 				C080D10921F66C77003FBCF4 /* UIColorExtension.swift in Sources */,
+				C2B8D8E42210EBD200C67D84 /* ComparableExtension.swift in Sources */,
 				C080D10D21F66C77003FBCF4 /* UIWindowExtension.swift in Sources */,
+				C2B8D8E72210EBEB00C67D84 /* UIViewControllerExtension.swift in Sources */,
 				C080D10221F66C6A003FBCF4 /* CollectionExtension.swift in Sources */,
 				C080D10721F66C77003FBCF4 /* RangeReplaceableCollectionExtension.swift in Sources */,
 				C080D0FE21F66C5F003FBCF4 /* ArrayExtension.swift in Sources */,
 				C080D10121F66C68003FBCF4 /* CGSizeExtension.swift in Sources */,
 				C080D10621F66C77003FBCF4 /* NSLayoutConstraintExtension.swift in Sources */,
 				C080D10C21F66C77003FBCF4 /* UIViewExtension.swift in Sources */,
+				C2B8D8DE2210D63F00C67D84 /* UIViewBorderExtension.swift in Sources */,
 				C080D0FD21F66C5B003FBCF4 /* EventConnection.swift in Sources */,
+				C2B8D8E82210EBF100C67D84 /* UIViewShadowExtension.swift in Sources */,
 				C080D10321F66C6D003FBCF4 /* ContiguousArrayExtension.swift in Sources */,
 				C080D0FF21F66C62003FBCF4 /* CGPointExtension.swift in Sources */,
 				C080D10421F66C70003FBCF4 /* DataExtension.swift in Sources */,
@@ -1000,7 +985,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C2E865F22213705B002DD5D4 /* UIViewShadowExtensionTests.swift in Sources */,
 				C0A6037621F682D3009EC42C /* Tests.swift in Sources */,
+				C2E865F522137071002DD5D4 /* UIViewControllerExtensionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1016,6 +1003,7 @@
 				C0AE178321F678520070DD72 /* EventConnection.swift in Sources */,
 				C0AE178921F6785A0070DD72 /* ContiguousArrayExtension.swift in Sources */,
 				C0AE178521F6785A0070DD72 /* CGPointExtension.swift in Sources */,
+				C2B8D8E32210EBD100C67D84 /* ComparableExtension.swift in Sources */,
 				C0AE178A21F6785A0070DD72 /* DataExtension.swift in Sources */,
 				C0AE178B21F6785A0070DD72 /* FloatingPointExtension.swift in Sources */,
 				C0AE178E21F6785A0070DD72 /* StringExtension.swift in Sources */,
@@ -1050,20 +1038,24 @@
 				C05A654021F343C30038EC55 /* CollectionExtension.swift in Sources */,
 				C05A653621F26D5B0038EC55 /* EventConnection.swift in Sources */,
 				C05A655421F35AF80038EC55 /* CGSizeExtension.swift in Sources */,
+				C2B8D8E22210EB6100C67D84 /* ComparableExtension.swift in Sources */,
 				C0252D5521F3A35E00F41A26 /* ArrayExtension.swift in Sources */,
 				C05A654321F3450D0038EC55 /* RangeReplaceableCollectionExtension.swift in Sources */,
 				C0AFE91E21F4F29600A7005D /* UIColorExtension.swift in Sources */,
+				C2B8D8E02210D71400C67D84 /* UIViewShadowExtension.swift in Sources */,
 				C05A653521F26D590038EC55 /* Event.swift in Sources */,
 				C0336CE921F4B293006A182C /* UIViewExtension.swift in Sources */,
+				C2B8D8DB22108C3600C67D84 /* FloatingPointExtension.swift in Sources */,
 				C0252D7121F3DCD100F41A26 /* NSLayoutConstraintExtension.swift in Sources */,
+				C2B8D8DD2210D62100C67D84 /* UIViewBorderExtension.swift in Sources */,
 				C05A655221F35AA70038EC55 /* CGRectExtension.swift in Sources */,
 				C0252D7821F3E43F00F41A26 /* UIImageExtension.swift in Sources */,
 				C05A654621F353DA0038EC55 /* ContiguousArrayExtension.swift in Sources */,
 				C0252D6521F3D0A900F41A26 /* StringExtension.swift in Sources */,
-				C0252D5E21F3BEAA00F41A26 /* FloatingPointExtension.swift in Sources */,
 				C0336CEF21F4B955006A182C /* UIWindowExtension.swift in Sources */,
 				C05A654921F354C50038EC55 /* CGPointExtension.swift in Sources */,
 				C0252D7621F3E33500F41A26 /* UIEdgeInsetsExtension.swift in Sources */,
+				C2B8D8E62210EBEB00C67D84 /* UIViewControllerExtension.swift in Sources */,
 				C0252D5721F3A5AC00F41A26 /* DataExtension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1073,9 +1065,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				C05A656321F39A9B0038EC55 /* RangeReplaceableCollectionExtensionTests.swift in Sources */,
+				C2E865F722138022002DD5D4 /* Matchers.swift in Sources */,
 				C05A653821F282330038EC55 /* EventConnectionTests.swift in Sources */,
+				C2E865F422137071002DD5D4 /* UIViewControllerExtensionTests.swift in Sources */,
 				C05A655721F35FF40038EC55 /* CGSizeExtensionTests.swift in Sources */,
 				C05A653421F26C3C0038EC55 /* EventTests.swift in Sources */,
+				C2E865F12213705B002DD5D4 /* UIViewShadowExtensionTests.swift in Sources */,
 				C0252D7A21F3E4F200F41A26 /* UIImageExtensionTests.swift in Sources */,
 				C05A655F21F3951A0038EC55 /* CollectionExtensionTests.swift in Sources */,
 				C0252D6421F3D0A300F41A26 /* StringExtensionTests.swift in Sources */,
@@ -1084,6 +1079,7 @@
 				C0252D6021F3BEED00F41A26 /* FloatingPointExtensionTests.swift in Sources */,
 				C05A656121F399DE0038EC55 /* ContiguousArrayExtensionTests.swift in Sources */,
 				C05A654E21F355340038EC55 /* ArrayExtensionTests.swift in Sources */,
+				C2E865EE22136CAD002DD5D4 /* UIViewBorderExtensionTests.swift in Sources */,
 				C05A655A21F368830038EC55 /* CGRectExtensionTests.swift in Sources */,
 				C0AFE92021F4F63500A7005D /* UIColorExtensionTests.swift in Sources */,
 				C0336CF121F4B9F2006A182C /* UIWindowExtensionTests.swift in Sources */,
@@ -1091,6 +1087,7 @@
 				C0A6037521F682D3009EC42C /* Tests.swift in Sources */,
 				C0336CED21F4B42A006A182C /* UIViewExtensionTests.swift in Sources */,
 				C0252D7021F3DCCD00F41A26 /* NSLayoutConstraintTests.swift in Sources */,
+				C2E865FB22138DB0002DD5D4 /* ComparableExtensionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AurorKit/Events/EventConnection.swift
+++ b/AurorKit/Events/EventConnection.swift
@@ -25,12 +25,12 @@ public final class EventConnection<T> {
 
     // MARK: - Initializers
 
-    internal init(event: Event<T>, receiver: AnyObject, handler: @escaping Event<T>.Handler, isActive: Bool = true) {
+    internal init(event: Event<T>, receiver: AnyObject, handler: @escaping Event<T>.Handler, activated: Bool = true) {
         self.event = event
         self.receiver = receiver
         self.handler = handler
 
-        if isActive {
+        if activated {
             self.event?.register(connection: self)
         }
     }

--- a/AurorKit/Extensions/ComparableExtension.swift
+++ b/AurorKit/Extensions/ComparableExtension.swift
@@ -1,0 +1,30 @@
+//
+//  ComparableExtension.swift
+//  AurorKit
+//
+//  Created by Almaz Ibragimov on 11/02/2019.
+//  Copyright © 2019 Aurors. All rights reserved.
+//
+
+import Foundation
+
+extension Comparable {
+
+    // MARK: - Instance Methods
+
+    public mutating func clampBetween(lowerBound: Self, upperBound: Self) {
+        self = self.clampedBetween(lowerBound: lowerBound, upperBound: upperBound)
+    }
+
+    public mutating func clamp(to range: ClosedRange<Self>) {
+        self = self.clamped(to: range)
+    }
+
+    public func clampedBetween(lowerBound: Self, upperBound: Self) -> Self {
+        return min(max(self, lowerBound), upperBound)
+    }
+
+    public func clamped(to range: ClosedRange<Self>) -> Self {
+        return self.clampedBetween(lowerBound: range.lowerBound, upperBound: range.upperBound)
+    }
+}

--- a/AurorKit/Extensions/UIColorExtension.swift
+++ b/AurorKit/Extensions/UIColorExtension.swift
@@ -122,10 +122,10 @@ extension UIColor {
     // MARK: - Instance Properties
 
     public var argbHexString: String {
-        var red: CGFloat = 0
-        var green: CGFloat = 0
-        var blue: CGFloat = 0
-        var alpha: CGFloat = 0
+        var red: CGFloat = 0.0
+        var green: CGFloat = 0.0
+        var blue: CGFloat = 0.0
+        var alpha: CGFloat = 0.0
 
         self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 
@@ -144,10 +144,10 @@ extension UIColor {
     }
 
     public var rgbaHexString: String {
-        var red: CGFloat = 0
-        var green: CGFloat = 0
-        var blue: CGFloat = 0
-        var alpha: CGFloat = 0
+        var red: CGFloat = 0.0
+        var green: CGFloat = 0.0
+        var blue: CGFloat = 0.0
+        var alpha: CGFloat = 0.0
 
         self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 
@@ -166,10 +166,10 @@ extension UIColor {
     }
 
     public var rgbHexString: String {
-        var red: CGFloat = 0
-        var green: CGFloat = 0
-        var blue: CGFloat = 0
-        var alpha: CGFloat = 0
+        var red: CGFloat = 0.0
+        var green: CGFloat = 0.0
+        var blue: CGFloat = 0.0
+        var alpha: CGFloat = 0.0
 
         self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 
@@ -180,10 +180,10 @@ extension UIColor {
     }
 
     public var argbHex: UInt32 {
-        var red: CGFloat = 0
-        var green: CGFloat = 0
-        var blue: CGFloat = 0
-        var alpha: CGFloat = 0
+        var red: CGFloat = 0.0
+        var green: CGFloat = 0.0
+        var blue: CGFloat = 0.0
+        var alpha: CGFloat = 0.0
 
         self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 
@@ -203,10 +203,10 @@ extension UIColor {
     }
 
     public var rgbaHex: UInt32 {
-        var red: CGFloat = 0
-        var green: CGFloat = 0
-        var blue: CGFloat = 0
-        var alpha: CGFloat = 0
+        var red: CGFloat = 0.0
+        var green: CGFloat = 0.0
+        var blue: CGFloat = 0.0
+        var alpha: CGFloat = 0.0
 
         self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 
@@ -226,10 +226,10 @@ extension UIColor {
     }
 
     public var rgbHex: UInt32 {
-        var red: CGFloat = 0
-        var green: CGFloat = 0
-        var blue: CGFloat = 0
-        var alpha: CGFloat = 0
+        var red: CGFloat = 0.0
+        var green: CGFloat = 0.0
+        var blue: CGFloat = 0.0
+        var alpha: CGFloat = 0.0
 
         self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 

--- a/AurorKit/Extensions/UIColorExtension.swift
+++ b/AurorKit/Extensions/UIColorExtension.swift
@@ -42,30 +42,92 @@ extension UIColor {
         self.init(white: CGFloat(whiteByte) / 255.0, alpha: alpha)
     }
 
-    public convenience init(argbHEX: UInt32) {
-        self.init(redByte: UInt8((argbHEX >> 16) & 255),
-                  greenByte: UInt8((argbHEX >> 8) & 255),
-                  blueByte: UInt8(argbHEX & 255),
-                  alphaByte: UInt8((argbHEX >> 24) & 255))
+    public convenience init?(argbHexString hexString: String) {
+        guard hexString.hasPrefix("#") else {
+            return nil
+        }
+
+        let scanner = Scanner(string: hexString)
+
+        scanner.scanLocation = 1
+        scanner.caseSensitive = false
+
+        var hex: UInt32 = 0
+
+        guard scanner.scanHexInt32(&hex) else {
+            return nil
+        }
+
+        self.init(argbHex: hex)
     }
 
-    public convenience init(rgbHEX: UInt32) {
-        self.init(redByte: UInt8((rgbHEX >> 16) & 255),
-                  greenByte: UInt8((rgbHEX >> 8) & 255),
-                  blueByte: UInt8(rgbHEX & 255))
+    public convenience init?(rgbaHexString hexString: String) {
+        guard hexString.hasPrefix("#") else {
+            return nil
+        }
+
+        let scanner = Scanner(string: hexString)
+
+        scanner.scanLocation = 1
+        scanner.caseSensitive = false
+
+        var hex: UInt32 = 0
+
+        guard scanner.scanHexInt32(&hex) else {
+            return nil
+        }
+
+        self.init(rgbaHex: hex)
+    }
+
+    public convenience init?(rgbHexString hexString: String) {
+        guard hexString.hasPrefix("#") else {
+            return nil
+        }
+
+        let scanner = Scanner(string: hexString)
+
+        scanner.scanLocation = 1
+        scanner.caseSensitive = false
+
+        var hex: UInt32 = 0
+
+        guard scanner.scanHexInt32(&hex) else {
+            return nil
+        }
+
+        self.init(rgbHex: hex)
+    }
+
+    public convenience init(argbHex hex: UInt32) {
+        self.init(redByte: UInt8((hex >> 16) & 255),
+                  greenByte: UInt8((hex >> 8) & 255),
+                  blueByte: UInt8(hex & 255),
+                  alphaByte: UInt8((hex >> 24) & 255))
+    }
+
+    public convenience init(rgbaHex hex: UInt32) {
+        self.init(redByte: UInt8((hex >> 24) & 255),
+                  greenByte: UInt8((hex >> 16) & 255),
+                  blueByte: UInt8((hex >> 8) & 255),
+                  alphaByte: UInt8(hex & 255))
+    }
+
+    public convenience init(rgbHex hex: UInt32) {
+        self.init(redByte: UInt8((hex >> 16) & 255),
+                  greenByte: UInt8((hex >> 8) & 255),
+                  blueByte: UInt8(hex & 255))
     }
 
     // MARK: - Instance Properties
 
-    public var argbHEXString: String {
+    public var argbHexString: String {
         var red: CGFloat = 0
         var green: CGFloat = 0
         var blue: CGFloat = 0
         var alpha: CGFloat = 0
 
-        guard self.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
-            return "#00000000"
-        }
+        self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 
         if alpha < 1.0 - CGFloat.leastNonzeroMagnitude {
             return String(format: "#%02lX%02lX%02lX%02lX",
@@ -81,15 +143,13 @@ extension UIColor {
         }
     }
 
-    public var rgbaHEXString: String {
+    public var rgbaHexString: String {
         var red: CGFloat = 0
         var green: CGFloat = 0
         var blue: CGFloat = 0
         var alpha: CGFloat = 0
 
-        guard self.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
-            return "#00000000"
-        }
+        self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 
         if alpha < 1.0 - CGFloat.leastNonzeroMagnitude {
             return String(format: "#%02lX%02lX%02lX%02lX",
@@ -105,15 +165,27 @@ extension UIColor {
         }
     }
 
-    public var argbHEX: UInt32 {
+    public var rgbHexString: String {
         var red: CGFloat = 0
         var green: CGFloat = 0
         var blue: CGFloat = 0
         var alpha: CGFloat = 0
 
-        guard self.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
-            return 0
-        }
+        self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        return String(format: "#%02lX%02lX%02lX",
+                      Int(red * 255.0),
+                      Int(green * 255.0),
+                      Int(blue * 255.0))
+    }
+
+    public var argbHex: UInt32 {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+
+        self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 
         let alphaByte: UInt32
 
@@ -130,15 +202,13 @@ extension UIColor {
         return alphaByte | redByte | greenByte | blueByte
     }
 
-    public var rgbaHEX: UInt32 {
+    public var rgbaHex: UInt32 {
         var red: CGFloat = 0
         var green: CGFloat = 0
         var blue: CGFloat = 0
         var alpha: CGFloat = 0
 
-        guard self.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
-            return 0
-        }
+        self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 
         let redByte = UInt32(red * 255.0) << 24
         let greenByte = UInt32(green * 255.0) << 16
@@ -153,5 +223,20 @@ extension UIColor {
         }
 
         return redByte | greenByte | blueByte | alphaByte
+    }
+
+    public var rgbHex: UInt32 {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+
+        self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        let redByte = UInt32(red * 255.0) << 16
+        let greenByte = UInt32(green * 255.0) << 8
+        let blueByte = UInt32(blue * 255.0)
+
+        return redByte | greenByte | blueByte
     }
 }

--- a/AurorKit/Extensions/UIImageExtension.swift
+++ b/AurorKit/Extensions/UIImageExtension.swift
@@ -10,6 +10,15 @@ import UIKit
 
 extension UIImage {
 
+    // MARK: - Instance Properties
+
+    public var alignmentRect: CGRect {
+        return CGRect(x: self.alignmentRectInsets.left,
+                      y: self.alignmentRectInsets.top,
+                      width: self.size.width - self.alignmentRectInsets.left - self.alignmentRectInsets.right,
+                      height: self.size.height - self.alignmentRectInsets.top - self.alignmentRectInsets.bottom)
+    }
+
     // MARK: - Instance Methods
 
     public final func scaled(to size: CGSize) -> UIImage? {

--- a/AurorKit/Extensions/UIViewBorderExtension.swift
+++ b/AurorKit/Extensions/UIViewBorderExtension.swift
@@ -1,0 +1,47 @@
+//
+//  UIViewBorderExtension.swift
+//  AurorKit
+//
+//  Created by Almaz Ibragimov on 11/02/2019.
+//  Copyright © 2019 Aurors. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+
+    // MARK: - Nested Types
+
+    public struct Border: Equatable {
+
+        // MARK: - Type Properties
+
+        public static let empty = Border()
+
+        // MARK: - Instance Properties
+
+        public let width: CGFloat
+        public let color: UIColor?
+
+        // MARK: - Initializers
+
+        public init(width: CGFloat = 0.0, color: UIColor? = .black) {
+            self.width = width
+            self.color = color
+        }
+    }
+
+    // MARK: - Instance Properties
+
+    public var border: Border {
+        get {
+            return Border(width: self.layer.borderWidth,
+                          color: self.layer.borderColor.map({ UIColor(cgColor: $0) }))
+        }
+
+        set {
+            self.layer.borderWidth = newValue.width
+            self.layer.borderColor = newValue.color?.cgColor
+        }
+    }
+}

--- a/AurorKit/Extensions/UIViewControllerExtension.swift
+++ b/AurorKit/Extensions/UIViewControllerExtension.swift
@@ -13,6 +13,6 @@ extension UIViewController {
     // MARK: - Instance Properties
 
     public var isVisible: Bool {
-        return viewIfLoaded?.window != nil
+        return !(self.viewIfLoaded?.window?.isHidden ?? true)
     }
 }

--- a/AurorKit/Extensions/UIViewControllerExtension.swift
+++ b/AurorKit/Extensions/UIViewControllerExtension.swift
@@ -1,0 +1,18 @@
+//
+//  UIViewControllerExtension.swift
+//  AurorKit
+//
+//  Created by Almaz Ibragimov on 11/02/2019.
+//  Copyright © 2019 Aurors. All rights reserved.
+//
+
+import UIKit
+
+extension UIViewController {
+
+    // MARK: - Instance Properties
+
+    public var isVisible: Bool {
+        return viewIfLoaded?.window != nil
+    }
+}

--- a/AurorKit/Extensions/UIViewShadowExtension.swift
+++ b/AurorKit/Extensions/UIViewShadowExtension.swift
@@ -1,0 +1,63 @@
+//
+//  UIViewShadowExtension.swift
+//  AurorKit
+//
+//  Created by Almaz Ibragimov on 11/02/2019.
+//  Copyright © 2019 Aurors. All rights reserved.
+//
+
+import UIKit
+
+extension UIView {
+
+    // MARK: - Nested Types
+
+    public struct Shadow: Equatable {
+
+        // MARK: - Type Properties
+
+        public static let empty = Shadow()
+
+        // MARK: - Instance Properties
+
+        public let offset: CGSize
+        public let radius: CGFloat
+        public let color: UIColor?
+        public let opacity: Float
+        public let shouldRasterize: Bool
+
+        // MARK: - Initializers
+
+        public init(offset: CGSize = CGSize(width: 0, height: -3),
+                    radius: CGFloat = 3.0,
+                    color: UIColor? = .black,
+                    opacity: Float = 0.0,
+                    shouldRasterize: Bool = false) {
+            self.offset = offset
+            self.radius = radius
+            self.color = color
+            self.opacity = opacity
+            self.shouldRasterize = shouldRasterize
+        }
+    }
+
+    // MARK: - Instance Properties
+
+    public var shadow: Shadow {
+        get {
+            return Shadow(offset: self.layer.shadowOffset,
+                          radius: self.layer.shadowRadius,
+                          color: self.layer.shadowColor.map({ UIColor(cgColor: $0) }),
+                          opacity: self.layer.shadowOpacity,
+                          shouldRasterize: self.layer.shouldRasterize)
+        }
+
+        set {
+            self.layer.shadowOffset = newValue.offset
+            self.layer.shadowRadius = newValue.radius
+            self.layer.shadowColor = newValue.color?.cgColor
+            self.layer.shadowOpacity = newValue.opacity
+            self.layer.shouldRasterize = newValue.shouldRasterize
+        }
+    }
+}

--- a/AurorKitTests/Events/EventConnectionTests.swift
+++ b/AurorKitTests/Events/EventConnectionTests.swift
@@ -22,87 +22,85 @@ class EventConnectionTests: QuickSpec {
         var eventHandler: MockEventHandler<Int>!
         var eventConnection: EventConnection<Int>!
 
-        beforeEach({
+        beforeEach {
             event = Event<Int>()
             eventHandler = MockEventHandler<Int>()
-        })
+        }
 
-        context("Initializers", {
-            describe(".init(event:, receiver:, handler:, isActive:)", {
-                it("should initialize properly", closure: {
-                    eventConnection = EventConnection<Int>(event: event,
-                                                           receiver: self,
-                                                           handler: eventHandler.handler)
-
-                    expect(eventConnection.event).to(beIdenticalTo(event))
-                    expect(eventConnection.receiver).to(beIdenticalTo(self))
-                    expect(eventConnection.isActive).to(beTrue())
-                })
-
-                it("should initialize as inactive", closure: {
-                    eventConnection = EventConnection<Int>(event: event,
-                                                           receiver: self,
-                                                           handler: eventHandler.handler,
-                                                           isActive: false)
-
-                    expect(eventConnection.isActive).to(beFalse())
-                    expect(event.connections.count).to(equal(0))
-                })
-
-                it("should initialize as active", closure: {
-                    eventConnection = EventConnection<Int>(event: event,
-                                                           receiver: self,
-                                                           handler: eventHandler.handler,
-                                                           isActive: true)
-
-                    expect(eventConnection.isActive).to(beTrue())
-                    expect(event.connections.count).to(equal(1))
-                    expect(event.connections.first).to(beIdenticalTo(eventConnection))
-                })
-            })
-        })
-
-        context("Instance Methods", {
-            beforeEach({
+        describe(".init(event:, receiver:, handler:, isActive:)") {
+            it("should initialize properly") {
                 eventConnection = EventConnection<Int>(event: event,
                                                        receiver: self,
                                                        handler: eventHandler.handler)
-            })
 
-            describe(".emit(data:)", {
-                it("should not call the handler prematurely", closure: {
+                expect(eventConnection.event).to(beIdenticalTo(event))
+                expect(eventConnection.receiver).to(beIdenticalTo(self))
+                expect(eventConnection.isActive).to(beTrue())
+            }
+
+            it("should initialize as inactive") {
+                eventConnection = EventConnection<Int>(event: event,
+                                                       receiver: self,
+                                                       handler: eventHandler.handler,
+                                                       activated: false)
+
+                expect(eventConnection.isActive).to(beFalse())
+                expect(event.connections.count).to(equal(0))
+            }
+
+            it("should initialize as active") {
+                eventConnection = EventConnection<Int>(event: event,
+                                                       receiver: self,
+                                                       handler: eventHandler.handler,
+                                                       activated: true)
+
+                expect(eventConnection.isActive).to(beTrue())
+                expect(event.connections.count).to(equal(1))
+                expect(event.connections.first).to(beIdenticalTo(eventConnection))
+            }
+        }
+
+        context("when it is initialized") {
+            beforeEach {
+                eventConnection = EventConnection<Int>(event: event,
+                                                       receiver: self,
+                                                       handler: eventHandler.handler)
+            }
+
+            describe(".emit(data:)") {
+                it("should not call the handler prematurely") {
                     expect(eventHandler.handlerCallCount).to(equal(0))
                     expect(eventHandler.handlerParameters).to(beNil())
-                })
+                }
 
-                it("should call the handler with the correct data", closure: {
+                it("should call the handler with the correct data") {
                     eventConnection.emit(data: 123)
 
                     expect(eventHandler.handlerCallCount).to(equal(1))
                     expect(eventHandler.handlerParameters).to(equal(123))
-                })
-            })
+                }
+            }
 
-            describe(".activate()", {
-                it("should change state to active", closure: {
+            describe(".activate()") {
+                it("should change state to active") {
                     eventConnection.deactivate()
                     eventConnection.activate()
 
                     expect(eventConnection.isActive).to(beTrue())
                     expect(event.connections.count).to(equal(1))
                     expect(event.connections.first).to(beIdenticalTo(eventConnection))
-                })
-            })
+                }
+            }
 
-            describe(".deactivate()", {
-                it("should change state to inactive", closure: {
+            describe(".deactivate()") {
+                it("should change state to inactive") {
                     eventConnection.activate()
                     eventConnection.deactivate()
 
                     expect(eventConnection.isActive).to(beFalse())
                     expect(event.connections.count).to(equal(0))
-                })
-            })
-        })
+                }
+            }
+        }
     }
 }

--- a/AurorKitTests/Events/EventTests.swift
+++ b/AurorKitTests/Events/EventTests.swift
@@ -18,115 +18,111 @@ class EventTests: QuickSpec {
     // MARK: - Instance Methods
 
     override func spec() {
-        context("Event where T is Int", {
+        context("Event where T is Int") {
             var event: Event<Int>!
             var eventHandler: MockEventHandler<Int>!
 
-            beforeEach({
+            beforeEach {
                 event = Event<Int>()
                 eventHandler = MockEventHandler<Int>()
-            })
+            }
 
-            context("Initializers", {
-                describe(".init()", {
-                    it("should initialize properly", closure: {
-                        expect(event.connections).to(beEmpty())
-                    })
-                })
-            })
+            describe(".init()") {
+                it("should initialize properly") {
+                    expect(event.connections).to(beEmpty())
+                }
+            }
 
-            context("Instance Methods", {
+            context("when it has connections") {
                 var eventConnection: EventConnection<Int>!
 
-                beforeEach({
+                beforeEach {
                     eventConnection = event.connect(self, handler: eventHandler.handler)
-                })
+                }
 
-                describe(".register(connection:)", {
-                    it("should re-register the connection", closure: {
+                describe(".register(connection:)") {
+                    it("should re-register the connection") {
                         event.register(connection: eventConnection)
 
                         expect(event.connections.count).to(equal(1))
                         expect(event.connections.first).to(beIdenticalTo(eventConnection))
-                    })
-                })
+                    }
+                }
 
-                describe(".unregister(connection:)", {
-                    it("should unregister the connection", closure: {
+                describe(".unregister(connection:)") {
+                    it("should unregister the connection") {
                         event.unregister(connection: eventConnection)
 
                         expect(event.connections).toNot(containElementSatisfying({ $0 === eventConnection }))
-                    })
-                })
+                    }
+                }
 
-                describe(".connect(_ receiver:, handler:)", {
-                    it("should create the properly connection", closure: {
+                describe(".connect(_ receiver:, handler:)") {
+                    it("should create a valid connection") {
                         expect(eventConnection.event).to(beIdenticalTo(event))
                         expect(eventConnection.receiver).to(beIdenticalTo(self))
                         expect(eventConnection.isActive).to(beTrue())
-                    })
+                    }
 
-                    it("should register the created connection", closure: {
+                    it("should register the created connection") {
                         expect(event.connections.count).to(equal(1))
                         expect(event.connections.first).to(beIdenticalTo(eventConnection))
-                    })
-                })
+                    }
+                }
 
-                describe(".disconnect(_ receiver:)", {
-                    it("should unregister all connections of the receiver", closure: {
+                describe(".disconnect(_ receiver:)") {
+                    it("should unregister all connections of the receiver") {
                         event.disconnect(self)
 
                         expect(event.connections).toNot(containElementSatisfying({ $0.receiver === self }))
-                    })
-                })
+                    }
+                }
 
-                describe(".emit(data:)", {
-                    it("should not call the handler prematurely", closure: {
+                describe(".emit(data:)") {
+                    it("should not call the handler prematurely") {
                         expect(eventHandler.handlerCallCount).to(equal(0))
                         expect(eventHandler.handlerParameters).to(beNil())
-                    })
+                    }
 
-                    it("should not call the handler when the connection is deactivated", closure: {
+                    it("should not call the handler when the connection is deactivated") {
                         eventConnection.deactivate()
 
                         event.emit(data: 123)
 
                         expect(eventHandler.handlerCallCount).to(equal(0))
                         expect(eventHandler.handlerParameters).to(beNil())
-                    })
+                    }
 
-                    it("should call the handler with the correct data", closure: {
+                    it("should call the handler with the correct data") {
                         event.emit(data: 123)
 
                         expect(eventHandler.handlerCallCount).to(equal(1))
                         expect(eventHandler.handlerParameters).to(equal(123))
-                    })
-                })
-            })
-        })
+                    }
+                }
+            }
+        }
 
-        context("Event where T is Void", {
+        context("Event where T is Void") {
             var event: Event<Void>!
             var eventHandler: MockEventHandler<Void>!
 
-            beforeEach({
+            beforeEach {
                 event = Event<Void>()
                 eventHandler = MockEventHandler<Void>()
-            })
+            }
 
-            context("Instance Methods", {
-                describe(".emit()", {
-                    it("should call the handler with the correct data", closure: {
-                        event.connect(self, handler: eventHandler.handler)
+            describe(".emit()") {
+                it("should call the handler with the correct data") {
+                    event.connect(self, handler: eventHandler.handler)
 
-                        event.emit()
+                    event.emit()
 
-                        expect(eventHandler.handlerCallCount).to(equal(1))
-                        expect(eventHandler.handlerParameters).toNot(beNil())
-                    })
-                })
-            })
-        })
+                    expect(eventHandler.handlerCallCount).to(equal(1))
+                    expect(eventHandler.handlerParameters).toNot(beNil())
+                }
+            }
+        }
     }
 }
 

--- a/AurorKitTests/Extensions/ArrayExtensionTests.swift
+++ b/AurorKitTests/Extensions/ArrayExtensionTests.swift
@@ -18,32 +18,30 @@ class ArrayExtensionTests: QuickSpec {
     // MARK: - Instance Methods
 
     override func spec() {
-        context("Instance Methods", {
-            describe(".removeLast(where:)", {
-                it("should not change the array", closure: {
-                    var array: [Int] = []
+        describe(".removeLast(where:)") {
+            it("should not change the array") {
+                var array: [Int] = []
 
-                    array.removeLast(where: { ($0 % 2) == 0 })
+                array.removeLast(where: { ($0 % 2) == 0 })
 
-                    expect(array).to(beEmpty())
-                })
+                expect(array).to(beEmpty())
+            }
 
-                it("should remove the last even number", closure: {
-                    var array = [1, 2, 3, 4, 5]
+            it("should remove the last even number") {
+                var array = [1, 2, 3, 4, 5]
 
-                    array.removeLast(where: { ($0 % 2) == 0 })
+                array.removeLast(where: { ($0 % 2) == 0 })
 
-                    expect(array).to(equal([1, 2, 3, 5]))
-                })
+                expect(array).to(equal([1, 2, 3, 5]))
+            }
 
-                it("should not change the array", closure: {
-                    var array = [1, 3, 5, 7]
+            it("should not change the array") {
+                var array = [1, 3, 5, 7]
 
-                    array.removeLast(where: { ($0 % 2) == 0 })
+                array.removeLast(where: { ($0 % 2) == 0 })
 
-                    expect(array).to(equal([1, 3, 5, 7]))
-                })
-            })
-        })
+                expect(array).to(equal([1, 3, 5, 7]))
+            }
+        }
     }
 }

--- a/AurorKitTests/Extensions/CGPointExtensionTests.swift
+++ b/AurorKitTests/Extensions/CGPointExtensionTests.swift
@@ -19,32 +19,30 @@ class CGPointExtensionTests: QuickSpec {
     // MARK: - Instance Methods
 
     override func spec() {
-        context("Instance Properties", {
-            describe(".adjusted", {
-                it("should return the adjusted point", closure: {
-                    let point = CGPoint(x: 1.4, y: 2.5).adjusted
+        describe(".adjusted") {
+            it("should return a properly adjusted point") {
+                let point = CGPoint(x: 1.4, y: 2.5).adjusted
 
-                    expect(point).to(equal(CGPoint(x: 1.0, y: 2.0)))
-                })
+                expect(point).to(equal(CGPoint(x: 1.0, y: 2.0)))
+            }
 
-                it("should return the adjusted point", closure: {
-                    let point = CGPoint(x: 1.5, y: 2.6).adjusted
+            it("should return a properly adjusted point") {
+                let point = CGPoint(x: 1.5, y: 2.6).adjusted
 
-                    expect(point).to(equal(CGPoint(x: 1.0, y: 2.0)))
-                })
+                expect(point).to(equal(CGPoint(x: 1.0, y: 2.0)))
+            }
 
-                it("should return the adjusted point", closure: {
-                    let point = CGPoint(x: -1.4, y: -2.5).adjusted
+            it("should return a properly adjusted point") {
+                let point = CGPoint(x: -1.4, y: -2.5).adjusted
 
-                    expect(point).to(equal(CGPoint(x: -2.0, y: -3.0)))
-                })
+                expect(point).to(equal(CGPoint(x: -2.0, y: -3.0)))
+            }
 
-                it("should return the adjusted point", closure: {
-                    let point = CGPoint(x: -1.5, y: -2.6).adjusted
+            it("should return a properly adjusted point") {
+                let point = CGPoint(x: -1.5, y: -2.6).adjusted
 
-                    expect(point).to(equal(CGPoint(x: -2.0, y: -3.0)))
-                })
-            })
-        })
+                expect(point).to(equal(CGPoint(x: -2.0, y: -3.0)))
+            }
+        }
     }
 }

--- a/AurorKitTests/Extensions/CGRectExtensionTests.swift
+++ b/AurorKitTests/Extensions/CGRectExtensionTests.swift
@@ -19,172 +19,168 @@ class CGRectExtensionTests: QuickSpec {
     // MARK: - Instance Methods
 
     override func spec() {
-        context("Instance Properties", {
-            describe(".top", {
-                it("should return the correct coordinate", closure: {
-                    let top = CGRect(x: 1.0, y: 2.0, width: 3.0, height: 4.0).top
+        describe(".init(x:, y:, size:)") {
+            it("should initialize properly") {
+                let rect = CGRect(x: CGFloat(1.2),
+                                  y: CGFloat(3.4),
+                                  size: CGSize(width: 5.6, height: 7.8))
 
-                    expect(top).to(equal(2.0))
-                })
+                expect(rect.origin.x).to(equal(1.2))
+                expect(rect.origin.y).to(equal(3.4))
+                expect(rect.size.width).to(equal(5.6))
+                expect(rect.size.height).to(equal(7.8))
+            }
 
-                it("should return the correct coordinate", closure: {
-                    let top = CGRect(x: -1.0, y: -2.0, width: -3.0, height: -4.0).top
+            it("should initialize properly") {
+                let rect = CGRect(x: Double(1.2),
+                                  y: Double(3.4),
+                                  size: CGSize(width: 5.6, height: 7.8))
 
-                    expect(top).to(equal(-6.0))
-                })
-            })
+                expect(rect.origin.x).to(equal(1.2))
+                expect(rect.origin.y).to(equal(3.4))
+                expect(rect.size.width).to(equal(5.6))
+                expect(rect.size.height).to(equal(7.8))
+            }
 
-            describe(".left", {
-                it("should return the correct coordinate", closure: {
-                    let left = CGRect(x: 1.0, y: 2.0, width: 3.0, height: 4.0).left
+            it("should initialize properly") {
+                let rect = CGRect(x: Int(12),
+                                  y: Int(34),
+                                  size: CGSize(width: 56, height: 78))
 
-                    expect(left).to(equal(1.0))
-                })
+                expect(rect.origin.x).to(equal(12.0))
+                expect(rect.origin.y).to(equal(34.0))
+                expect(rect.size.width).to(equal(56.0))
+                expect(rect.size.height).to(equal(78.0))
+            }
+        }
 
-                it("should return the correct coordinate", closure: {
-                    let left = CGRect(x: -1.0, y: -2.0, width: -3.0, height: -4.0).left
+        describe(".init(origin:, width:, height:)") {
+            it("should initialize properly") {
+                let rect = CGRect(origin: CGPoint(x: 1.2, y: 3.4),
+                                  width: CGFloat(5.6),
+                                  height: CGFloat(7.8))
 
-                    expect(left).to(equal(-4.0))
-                })
-            })
+                expect(rect.origin.x).to(equal(1.2))
+                expect(rect.origin.y).to(equal(3.4))
+                expect(rect.size.width).to(equal(5.6))
+                expect(rect.size.height).to(equal(7.8))
+            }
 
-            describe(".bottom", {
-                it("should return the correct coordinate", closure: {
-                    let bottom = CGRect(x: 1.0, y: 2.0, width: 3.0, height: 4.0).bottom
+            it("should initialize properly") {
+                let rect = CGRect(origin: CGPoint(x: 1.2, y: 3.4),
+                                  width: Double(5.6),
+                                  height: Double(7.8))
 
-                    expect(bottom).to(equal(6.0))
-                })
+                expect(rect.origin.x).to(equal(1.2))
+                expect(rect.origin.y).to(equal(3.4))
+                expect(rect.size.width).to(equal(5.6))
+                expect(rect.size.height).to(equal(7.8))
+            }
 
-                it("should return the correct coordinate", closure: {
-                    let bottom = CGRect(x: -1.0, y: -2.0, width: -3.0, height: -4.0).bottom
+            it("should initialize properly") {
+                let rect = CGRect(origin: CGPoint(x: 12, y: 34),
+                                  width: Int(56),
+                                  height: Int(78))
 
-                    expect(bottom).to(equal(-2.0))
-                })
-            })
+                expect(rect.origin.x).to(equal(12.0))
+                expect(rect.origin.y).to(equal(34.0))
+                expect(rect.size.width).to(equal(56.0))
+                expect(rect.size.height).to(equal(78.0))
+            }
+        }
 
-            describe(".right", {
-                it("should return the correct coordinate", closure: {
-                    let right = CGRect(x: 1.0, y: 2.0, width: 3.0, height: 4.0).right
+        describe(".top") {
+            it("should return the correct coordinate") {
+                let top = CGRect(x: 1.0, y: 2.0, width: 3.0, height: 4.0).top
 
-                    expect(right).to(equal(4.0))
-                })
+                expect(top).to(equal(2.0))
+            }
 
-                it("should return the correct coordinate", closure: {
-                    let right = CGRect(x: -1.0, y: -2.0, width: -3.0, height: -4.0).right
+            it("should return the correct coordinate") {
+                let top = CGRect(x: -1.0, y: -2.0, width: -3.0, height: -4.0).top
 
-                    expect(right).to(equal(-1.0))
-                })
-            })
+                expect(top).to(equal(-6.0))
+            }
+        }
 
-            describe(".adjusted", {
-                it("should return the adjusted rect", closure: {
-                    let rect = CGRect(x: 1.4, y: 2.5, width: 3.4, height: 4.5).adjusted
+        describe(".left") {
+            it("should return the correct coordinate") {
+                let left = CGRect(x: 1.0, y: 2.0, width: 3.0, height: 4.0).left
 
-                    expect(rect).to(equal(CGRect(x: 1.0, y: 2.0, width: 4.0, height: 5.0)))
-                })
+                expect(left).to(equal(1.0))
+            }
 
-                it("should return the adjusted rect", closure: {
-                    let rect = CGRect(x: 1.5, y: 2.6, width: 3.5, height: 4.6).adjusted
+            it("should return the correct coordinate") {
+                let left = CGRect(x: -1.0, y: -2.0, width: -3.0, height: -4.0).left
 
-                    expect(rect).to(equal(CGRect(x: 1.0, y: 2.0, width: 4.0, height: 5.0)))
-                })
+                expect(left).to(equal(-4.0))
+            }
+        }
 
-                it("should return the adjusted rect", closure: {
-                    let rect = CGRect(x: -1.4, y: -2.5, width: 3.4, height: 4.5).adjusted
+        describe(".bottom") {
+            it("should return the correct coordinate") {
+                let bottom = CGRect(x: 1.0, y: 2.0, width: 3.0, height: 4.0).bottom
 
-                    expect(rect).to(equal(CGRect(x: -2.0, y: -3.0, width: 4.0, height: 5.0)))
-                })
+                expect(bottom).to(equal(6.0))
+            }
 
-                it("should return the adjusted rect", closure: {
-                    let rect = CGRect(x: -1.5, y: -2.6, width: 3.5, height: 4.6).adjusted
+            it("should return the correct coordinate") {
+                let bottom = CGRect(x: -1.0, y: -2.0, width: -3.0, height: -4.0).bottom
 
-                    expect(rect).to(equal(CGRect(x: -2.0, y: -3.0, width: 4.0, height: 5.0)))
-                })
+                expect(bottom).to(equal(-2.0))
+            }
+        }
 
-                it("should return the adjusted rect", closure: {
-                    let rect = CGRect(x: -1.4, y: -2.5, width: -3.4, height: -4.5).adjusted
+        describe(".right") {
+            it("should return the correct coordinate") {
+                let right = CGRect(x: 1.0, y: 2.0, width: 3.0, height: 4.0).right
 
-                    expect(rect).to(equal(CGRect(x: -5.0, y: -7.0, width: 4.0, height: 5.0)))
-                })
+                expect(right).to(equal(4.0))
+            }
 
-                it("should return the adjusted rect", closure: {
-                    let rect = CGRect(x: -1.5, y: -2.6, width: -3.5, height: -4.6).adjusted
+            it("should return the correct coordinate") {
+                let right = CGRect(x: -1.0, y: -2.0, width: -3.0, height: -4.0).right
 
-                    expect(rect).to(equal(CGRect(x: -5.0, y: -8.0, width: 4.0, height: 5.0)))
-                })
-            })
-        })
+                expect(right).to(equal(-1.0))
+            }
+        }
 
-        context("Initializers", {
-            describe(".init(x:, y:, size:)", {
-                it("should initialize properly", closure: {
-                    let rect = CGRect(x: CGFloat(1.2),
-                                      y: CGFloat(3.4),
-                                      size: CGSize(width: 5.6, height: 7.8))
+        describe(".adjusted") {
+            it("should return a properly adjusted rect") {
+                let rect = CGRect(x: 1.4, y: 2.5, width: 3.4, height: 4.5).adjusted
 
-                    expect(rect.origin.x).to(equal(1.2))
-                    expect(rect.origin.y).to(equal(3.4))
-                    expect(rect.size.width).to(equal(5.6))
-                    expect(rect.size.height).to(equal(7.8))
-                })
+                expect(rect).to(equal(CGRect(x: 1.0, y: 2.0, width: 4.0, height: 5.0)))
+            }
 
-                it("should initialize properly", closure: {
-                    let rect = CGRect(x: Double(1.2),
-                                      y: Double(3.4),
-                                      size: CGSize(width: 5.6, height: 7.8))
+            it("should return a properly adjusted rect") {
+                let rect = CGRect(x: 1.5, y: 2.6, width: 3.5, height: 4.6).adjusted
 
-                    expect(rect.origin.x).to(equal(1.2))
-                    expect(rect.origin.y).to(equal(3.4))
-                    expect(rect.size.width).to(equal(5.6))
-                    expect(rect.size.height).to(equal(7.8))
-                })
+                expect(rect).to(equal(CGRect(x: 1.0, y: 2.0, width: 4.0, height: 5.0)))
+            }
 
-                it("should initialize properly", closure: {
-                    let rect = CGRect(x: Int(12),
-                                      y: Int(34),
-                                      size: CGSize(width: 56, height: 78))
+            it("should return a properly adjusted rect") {
+                let rect = CGRect(x: -1.4, y: -2.5, width: 3.4, height: 4.5).adjusted
 
-                    expect(rect.origin.x).to(equal(12.0))
-                    expect(rect.origin.y).to(equal(34.0))
-                    expect(rect.size.width).to(equal(56.0))
-                    expect(rect.size.height).to(equal(78.0))
-                })
-            })
+                expect(rect).to(equal(CGRect(x: -2.0, y: -3.0, width: 4.0, height: 5.0)))
+            }
 
-            describe(".init(origin:, width:, height:)", {
-                it("should initialize properly", closure: {
-                    let rect = CGRect(origin: CGPoint(x: 1.2, y: 3.4),
-                                      width: CGFloat(5.6),
-                                      height: CGFloat(7.8))
+            it("should return a properly adjusted rect") {
+                let rect = CGRect(x: -1.5, y: -2.6, width: 3.5, height: 4.6).adjusted
 
-                    expect(rect.origin.x).to(equal(1.2))
-                    expect(rect.origin.y).to(equal(3.4))
-                    expect(rect.size.width).to(equal(5.6))
-                    expect(rect.size.height).to(equal(7.8))
-                })
+                expect(rect).to(equal(CGRect(x: -2.0, y: -3.0, width: 4.0, height: 5.0)))
+            }
 
-                it("should initialize properly", closure: {
-                    let rect = CGRect(origin: CGPoint(x: 1.2, y: 3.4),
-                                      width: Double(5.6),
-                                      height: Double(7.8))
+            it("should return a properly adjusted rect") {
+                let rect = CGRect(x: -1.4, y: -2.5, width: -3.4, height: -4.5).adjusted
 
-                    expect(rect.origin.x).to(equal(1.2))
-                    expect(rect.origin.y).to(equal(3.4))
-                    expect(rect.size.width).to(equal(5.6))
-                    expect(rect.size.height).to(equal(7.8))
-                })
+                expect(rect).to(equal(CGRect(x: -5.0, y: -7.0, width: 4.0, height: 5.0)))
+            }
 
-                it("should initialize properly", closure: {
-                    let rect = CGRect(origin: CGPoint(x: 12, y: 34),
-                                      width: Int(56),
-                                      height: Int(78))
+            it("should return a properly adjusted rect") {
+                let rect = CGRect(x: -1.5, y: -2.6, width: -3.5, height: -4.6).adjusted
 
-                    expect(rect.origin.x).to(equal(12.0))
-                    expect(rect.origin.y).to(equal(34.0))
-                    expect(rect.size.width).to(equal(56.0))
-                    expect(rect.size.height).to(equal(78.0))
-                })
-            })
-        })
+                expect(rect).to(equal(CGRect(x: -5.0, y: -8.0, width: 4.0, height: 5.0)))
+            }
+        }
     }
 }

--- a/AurorKitTests/Extensions/CGSizeExtensionTests.swift
+++ b/AurorKitTests/Extensions/CGSizeExtensionTests.swift
@@ -19,57 +19,53 @@ class CGSizeExtensionTests: QuickSpec {
     // MARK: - Instance Methods
 
     override func spec() {
-        context("Instance Properties", {
-            describe(".adjusted", {
-                it("should return the adjusted size", closure: {
-                    let size = CGSize(width: 1.4, height: 2.5).adjusted
+        describe(".init(equilateral:)") {
+            it("should initialize properly") {
+                let size = CGSize(equilateral: CGFloat(1.23))
 
-                    expect(size).to(equal(CGSize(width: 2.0, height: 3.0)))
-                })
+                expect(size.width).to(equal(1.23))
+                expect(size.height).to(equal(1.23))
+            }
 
-                it("should return the adjusted size", closure: {
-                    let size = CGSize(width: 1.5, height: 2.6).adjusted
+            it("should initialize properly") {
+                let size = CGSize(equilateral: Double(1.23))
 
-                    expect(size).to(equal(CGSize(width: 2.0, height: 3.0)))
-                })
+                expect(size.width).to(equal(1.23))
+                expect(size.height).to(equal(1.23))
+            }
 
-                it("should return the adjusted size", closure: {
-                    let size = CGSize(width: -1.4, height: -2.5).adjusted
+            it("should initialize properly") {
+                let size = CGSize(equilateral: Int(123))
 
-                    expect(size).to(equal(CGSize(width: -2.0, height: -3.0)))
-                })
+                expect(size.width).to(equal(123.0))
+                expect(size.height).to(equal(123.0))
+            }
+        }
 
-                it("should return the adjusted size", closure: {
-                    let size = CGSize(width: -1.5, height: -2.6).adjusted
+        describe(".adjusted") {
+            it("should return a properly adjusted size") {
+                let size = CGSize(width: 1.4, height: 2.5).adjusted
 
-                    expect(size).to(equal(CGSize(width: -2.0, height: -3.0)))
-                })
-            })
-        })
+                expect(size).to(equal(CGSize(width: 2.0, height: 3.0)))
+            }
 
-        context("Initializers", {
-            describe(".init(equilateral:)", {
-                it("should initialize properly", closure: {
-                    let size = CGSize(equilateral: CGFloat(1.23))
+            it("should return a properly adjusted size") {
+                let size = CGSize(width: 1.5, height: 2.6).adjusted
 
-                    expect(size.width).to(equal(1.23))
-                    expect(size.height).to(equal(1.23))
-                })
+                expect(size).to(equal(CGSize(width: 2.0, height: 3.0)))
+            }
 
-                it("should initialize properly", closure: {
-                    let size = CGSize(equilateral: Double(1.23))
+            it("should return a properly adjusted size") {
+                let size = CGSize(width: -1.4, height: -2.5).adjusted
 
-                    expect(size.width).to(equal(1.23))
-                    expect(size.height).to(equal(1.23))
-                })
+                expect(size).to(equal(CGSize(width: -2.0, height: -3.0)))
+            }
 
-                it("should initialize properly", closure: {
-                    let size = CGSize(equilateral: Int(123))
+            it("should return a properly adjusted size") {
+                let size = CGSize(width: -1.5, height: -2.6).adjusted
 
-                    expect(size.width).to(equal(123.0))
-                    expect(size.height).to(equal(123.0))
-                })
-            })
-        })
+                expect(size).to(equal(CGSize(width: -2.0, height: -3.0)))
+            }
+        }
     }
 }

--- a/AurorKitTests/Extensions/CollectionExtensionTests.swift
+++ b/AurorKitTests/Extensions/CollectionExtensionTests.swift
@@ -18,100 +18,96 @@ class CollectionExtensionTests: QuickSpec {
     // MARK: - Instance Methods
 
     override func spec() {
-        context("Instance Subscripts", {
-            describe(".subscript(safe:)", {
-                it("should return an element", closure: {
-                    let collection = [1, 2, 3, 4, 5]
+        describe(".subscript(safe:)") {
+            it("should return an element") {
+                let collection = [1, 2, 3, 4, 5]
 
-                    expect(collection[safe: 0]).to(equal(1))
-                })
+                expect(collection[safe: 0]).to(equal(1))
+            }
 
-                it("should return an element", closure: {
-                    let collection = [1, 2, 3, 4, 5]
+            it("should return an element") {
+                let collection = [1, 2, 3, 4, 5]
 
-                    expect(collection[safe: 4]).to(equal(5))
-                })
+                expect(collection[safe: 4]).to(equal(5))
+            }
 
-                it("should return nil", closure: {
-                    let collection = [1, 2, 3, 4, 5]
+            it("should return nil") {
+                let collection = [1, 2, 3, 4, 5]
 
-                    expect(collection[safe: 5]).to(beNil())
-                })
-            })
-        })
+                expect(collection[safe: 5]).to(beNil())
+            }
+        }
 
-        context("Instance Methods", {
-            describe(".contains(index:)", {
-                it("should contains the index", closure: {
-                    let collection = [1, 2, 3, 4, 5]
+        describe(".contains(index:)") {
+            it("should contains the index") {
+                let collection = [1, 2, 3, 4, 5]
 
-                    expect(collection.contains(index: 0)).to(beTrue())
-                })
+                expect(collection.contains(index: 0)).to(beTrue())
+            }
 
-                it("should contains the index", closure: {
-                    let collection = [1, 2, 3, 4, 5]
+            it("should contains the index") {
+                let collection = [1, 2, 3, 4, 5]
 
-                    expect(collection.contains(index: 4)).to(beTrue())
-                })
+                expect(collection.contains(index: 4)).to(beTrue())
+            }
 
-                it("should not contains the index", closure: {
-                    let collection = [1, 2, 3, 4, 5]
+            it("should not contains the index") {
+                let collection = [1, 2, 3, 4, 5]
 
-                    expect(collection.contains(index: 5)).to(beFalse())
-                })
-            })
+                expect(collection.contains(index: 5)).to(beFalse())
+            }
+        }
 
-            describe(".split(maxSplits:, by:)", {
-                it("should return empty collection", closure: {
-                    let collection = [Int]().split(maxSplits: 1, by: { $0 == $1 })
+        describe(".split(maxSplits:, by:)") {
+            it("should return an empty collection") {
+                let collection = [Int]().split(maxSplits: 1, by: { $0 == $1 })
 
-                    expect(collection).to(beEmpty())
-                })
+                expect(collection).to(beEmpty())
+            }
 
-                it("should return a properly split collection", closure: {
-                    let collection = [1, 2, 3, 4, 5].split(maxSplits: 0, by: { $0 == $1 })
+            it("should return a properly split collection") {
+                let collection = [1, 2, 3, 4, 5].split(maxSplits: 0, by: { $0 == $1 })
 
-                    expect(collection).to(equal([[1, 2, 3, 4, 5]]))
-                })
+                expect(collection).to(equal([[1, 2, 3, 4, 5]]))
+            }
 
-                it("should return a properly split collection", closure: {
-                    let collection = [1, 2, 3, 4, 5].split(maxSplits: 1, by: { $0 == $1 })
+            it("should return a properly split collection") {
+                let collection = [1, 2, 3, 4, 5].split(maxSplits: 1, by: { $0 == $1 })
 
-                    expect(collection).to(equal([[1], [2, 3, 4, 5]]))
-                })
+                expect(collection).to(equal([[1], [2, 3, 4, 5]]))
+            }
 
-                it("should return a properly split collection", closure: {
-                    let collection = [1, 2, 3, 4, 5].split(maxSplits: 5, by: { $0 == $1 })
+            it("should return a properly split collection") {
+                let collection = [1, 2, 3, 4, 5].split(maxSplits: 5, by: { $0 == $1 })
 
-                    expect(collection).to(equal([[1], [2], [3], [4], [5]]))
-                })
+                expect(collection).to(equal([[1], [2], [3], [4], [5]]))
+            }
 
-                it("should return a properly split collection", closure: {
-                    let collection = [1, 1, 2, 3, 3, 3].split(maxSplits: 3, by: { $0 == $1 })
+            it("should return a properly split collection") {
+                let collection = [1, 1, 2, 3, 3, 3].split(maxSplits: 3, by: { $0 == $1 })
 
-                    expect(collection).to(equal([[1, 1], [2], [3, 3, 3]]))
-                })
-            })
+                expect(collection).to(equal([[1, 1], [2], [3, 3, 3]]))
+            }
+        }
 
-            describe(".split(by:)", {
-                it("should return empty collection", closure: {
-                    let collection = [Int]().split(by: { $0 == $1 })
+        describe(".split(by:)") {
+            it("should return an empty collection") {
+                let collection = [Int]().split(by: { $0 == $1 })
 
-                    expect(collection).to(beEmpty())
-                })
+                expect(collection).to(beEmpty())
+            }
 
-                it("should return a properly split collection", closure: {
-                    let collection = [1, 2, 3, 4, 5].split(by: { $0 == $1 })
+            it("should return a properly split collection") {
+                let collection = [1, 2, 3, 4, 5].split(by: { $0 == $1 })
 
-                    expect(collection).to(equal([[1], [2], [3], [4], [5]]))
-                })
+                expect(collection).to(equal([[1], [2], [3], [4], [5]]))
+            }
 
-                it("should return a properly split collection", closure: {
-                    let collection = [1, 1, 2, 3, 3, 3].split(by: { $0 == $1 })
+            it("should return a properly split collection") {
+                let collection = [1, 1, 2, 3, 3, 3].split(by: { $0 == $1 })
 
-                    expect(collection).to(equal([[1, 1], [2], [3, 3, 3]]))
-                })
-            })
-        })
+                expect(collection).to(equal([[1, 1], [2], [3, 3, 3]]))
+            }
+        }
     }
 }

--- a/AurorKitTests/Extensions/ComparableExtensionTests.swift
+++ b/AurorKitTests/Extensions/ComparableExtensionTests.swift
@@ -1,0 +1,211 @@
+//
+//  ComparableExtensionTests.swift
+//  AurorKit
+//
+//  Created by Almaz Ibragimov on 13/02/2019.
+//  Copyright © 2019 Aurors. All rights reserved.
+//
+
+import Foundation
+
+import Quick
+import Nimble
+
+@testable import AurorKit
+
+class ComparableExtensionTests: QuickSpec {
+
+    // MARK: - Instance Methods
+
+    override func spec() {
+        describe(".clampBetween(lowerBound:, upperBound:)") {
+            it("should clamp the number properly") {
+                var number = 456
+
+                number.clampBetween(lowerBound: 123, upperBound: 789)
+
+                expect(number).to(equal(456))
+            }
+
+            it("should clamp the number properly") {
+                var number = 123
+
+                number.clampBetween(lowerBound: 123, upperBound: 456)
+
+                expect(number).to(equal(123))
+            }
+
+            it("should clamp the number properly") {
+                var number = 456
+
+                number.clampBetween(lowerBound: 123, upperBound: 456)
+
+                expect(number).to(equal(456))
+            }
+
+            it("should clamp the number properly") {
+                var number = 123
+
+                number.clampBetween(lowerBound: 456, upperBound: 789)
+
+                expect(number).to(equal(456))
+            }
+
+            it("should clamp the number properly") {
+                var number = 789
+
+                number.clampBetween(lowerBound: 123, upperBound: 456)
+
+                expect(number).to(equal(456))
+            }
+
+            it("should clamp the number properly") {
+                var number = 456
+
+                number.clampBetween(lowerBound: 123, upperBound: 123)
+
+                expect(number).to(equal(123))
+            }
+
+            it("should clamp the number properly") {
+                var number = 456
+
+                number.clampBetween(lowerBound: 789, upperBound: 123)
+
+                expect(number).to(equal(123))
+            }
+        }
+
+        describe(".clamp(to:)") {
+            it("should clamp the number properly") {
+                var number = 456
+
+                number.clamp(to: 123...789)
+
+                expect(number).to(equal(456))
+            }
+
+            it("should clamp the number properly") {
+                var number = 123
+
+                number.clamp(to: 123...456)
+
+                expect(number).to(equal(123))
+            }
+
+            it("should clamp the number properly") {
+                var number = 456
+
+                number.clamp(to: 123...456)
+
+                expect(number).to(equal(456))
+            }
+
+            it("should clamp the number properly") {
+                var number = 123
+
+                number.clamp(to: 456...789)
+
+                expect(number).to(equal(456))
+            }
+
+            it("should clamp the number properly") {
+                var number = 789
+
+                number.clamp(to: 123...456)
+
+                expect(number).to(equal(456))
+            }
+
+            it("should clamp the number properly") {
+                var number = 456
+
+                number.clamp(to: 123...123)
+
+                expect(number).to(equal(123))
+            }
+        }
+
+        describe(".clampedBetween(lowerBound:, upperBound:)") {
+            it("should return a properly clamped number") {
+                let number = 456.clampedBetween(lowerBound: 123, upperBound: 789)
+
+                expect(number).to(equal(456))
+            }
+
+            it("should return a properly clamped number") {
+                let number = 123.clampedBetween(lowerBound: 123, upperBound: 456)
+
+                expect(number).to(equal(123))
+            }
+
+            it("should return a properly clamped number") {
+                let number = 456.clampedBetween(lowerBound: 123, upperBound: 456)
+
+                expect(number).to(equal(456))
+            }
+
+            it("should return a properly clamped number") {
+                let number = 123.clampedBetween(lowerBound: 456, upperBound: 789)
+
+                expect(number).to(equal(456))
+            }
+
+            it("should return a properly clamped number") {
+                let number = 789.clampedBetween(lowerBound: 123, upperBound: 456)
+
+                expect(number).to(equal(456))
+            }
+
+            it("should return a properly clamped number") {
+                let number = 456.clampedBetween(lowerBound: 123, upperBound: 123)
+
+                expect(number).to(equal(123))
+            }
+
+            it("should return a properly clamped number") {
+                let number = 456.clampedBetween(lowerBound: 789, upperBound: 123)
+
+                expect(number).to(equal(123))
+            }
+        }
+
+        describe(".clamped(to:)") {
+            it("should return a properly clamped number") {
+                let number = 456.clamped(to: 123...789)
+
+                expect(number).to(equal(456))
+            }
+
+            it("should return a properly clamped number") {
+                let number = 123.clamped(to: 123...456)
+
+                expect(number).to(equal(123))
+            }
+
+            it("should return a properly clamped number") {
+                let number = 456.clamped(to: 123...456)
+
+                expect(number).to(equal(456))
+            }
+
+            it("should return a properly clamped number") {
+                let number = 123.clamped(to: 456...789)
+
+                expect(number).to(equal(456))
+            }
+
+            it("should return a properly clamped number") {
+                let number = 789.clamped(to: 123...456)
+
+                expect(number).to(equal(456))
+            }
+
+            it("should return a properly clamped number") {
+                let number = 456.clamped(to: 123...123)
+
+                expect(number).to(equal(123))
+            }
+        }
+    }
+}

--- a/AurorKitTests/Extensions/ContiguousArrayExtensionTests.swift
+++ b/AurorKitTests/Extensions/ContiguousArrayExtensionTests.swift
@@ -18,32 +18,30 @@ class ContiguousArrayExtensionTests: QuickSpec {
     // MARK: - Instance Methods
 
     override func spec() {
-        context("Instance Methods", {
-            describe(".removeLast(where:)", {
-                it("should not change the array", closure: {
-                    var array = ContiguousArray<Int>()
+        describe(".removeLast(where:)") {
+            it("should not change the array") {
+                var array = ContiguousArray<Int>()
 
-                    array.removeLast(where: { ($0 % 2) == 0 })
+                array.removeLast(where: { ($0 % 2) == 0 })
 
-                    expect(array).to(beEmpty())
-                })
+                expect(array).to(beEmpty())
+            }
 
-                it("should remove the last even number", closure: {
-                    var array: ContiguousArray<Int> = [1, 2, 3, 4, 5]
+            it("should remove the last even number") {
+                var array: ContiguousArray<Int> = [1, 2, 3, 4, 5]
 
-                    array.removeLast(where: { ($0 % 2) == 0 })
+                array.removeLast(where: { ($0 % 2) == 0 })
 
-                    expect(array).to(equal([1, 2, 3, 5]))
-                })
+                expect(array).to(equal([1, 2, 3, 5]))
+            }
 
-                it("should not change the array", closure: {
-                    var array: ContiguousArray<Int> = [1, 3, 5, 7]
+            it("should not change the array") {
+                var array: ContiguousArray<Int> = [1, 3, 5, 7]
 
-                    array.removeLast(where: { ($0 % 2) == 0 })
+                array.removeLast(where: { ($0 % 2) == 0 })
 
-                    expect(array).to(equal([1, 3, 5, 7]))
-                })
-            })
-        })
+                expect(array).to(equal([1, 3, 5, 7]))
+            }
+        }
     }
 }

--- a/AurorKitTests/Extensions/DataExtensionTests.swift
+++ b/AurorKitTests/Extensions/DataExtensionTests.swift
@@ -18,20 +18,18 @@ class DataExtensionTests: QuickSpec {
     // MARK: - Instance Methods
 
     override func spec() {
-        context("Instance Properties", {
-            describe(".hexEncoded", {
-                it("should return an empty string", closure: {
-                    let data = Data()
+        describe(".hexEncoded") {
+            it("should return an empty string") {
+                let data = Data()
 
-                    expect(data.hexEncoded).to(beEmpty())
-                })
+                expect(data.hexEncoded).to(beEmpty())
+            }
 
-                it("should return the data as a HEX string", closure: {
-                    let data = Data([0, 1, 10, 16, 128, 255])
+            it("should return the data as a HEX string") {
+                let data = Data([0, 1, 10, 16, 128, 255])
 
-                    expect(data.hexEncoded).to(equal("00010a1080ff"))
-                })
-            })
-        })
+                expect(data.hexEncoded).to(equal("00010a1080ff"))
+            }
+        }
     }
 }

--- a/AurorKitTests/Extensions/FloatingPointExtensionTests.swift
+++ b/AurorKitTests/Extensions/FloatingPointExtensionTests.swift
@@ -18,58 +18,56 @@ class FloatingPointExtensionTests: QuickSpec {
     // MARK: - Instance Methods
 
     override func spec() {
-        context("Instance Properties", {
-            describe(".degreesToRadians", {
-                it("should return a value in radians", closure: {
-                    let degrees = 0.0
+        describe(".degreesToRadians") {
+            it("should return the angle in radians") {
+                let degrees = 0.0
 
-                    expect(degrees.degreesToRadians).to(equal(0.0))
-                })
+                expect(degrees.degreesToRadians).to(equal(0.0))
+            }
 
-                it("should return a value in radians", closure: {
-                    let degrees = 90.0
+            it("should return the angle in radians") {
+                let degrees = 90.0
 
-                    expect(degrees.degreesToRadians).to(equal(Double.pi / 2.0))
-                })
+                expect(degrees.degreesToRadians).to(equal(Double.pi / 2.0))
+            }
 
-                it("should return a value in radians", closure: {
-                    let degrees = 180.0
+            it("should return the angle in radians") {
+                let degrees = 180.0
 
-                    expect(degrees.degreesToRadians).to(equal(Double.pi))
-                })
+                expect(degrees.degreesToRadians).to(equal(Double.pi))
+            }
 
-                it("should return a value in radians", closure: {
-                    let degrees = 360.0
+            it("should return the angle in radians") {
+                let degrees = 360.0
 
-                    expect(degrees.degreesToRadians).to(equal(Double.pi * 2))
-                })
-            })
+                expect(degrees.degreesToRadians).to(equal(Double.pi * 2))
+            }
+        }
 
-            describe(".radiansToDegrees", {
-                it("should return a value in degrees", closure: {
-                    let radians = 0.0
+        describe(".radiansToDegrees") {
+            it("should return the angle in degrees") {
+                let radians = 0.0
 
-                    expect(radians.radiansToDegrees).to(equal(0.0))
-                })
+                expect(radians.radiansToDegrees).to(equal(0.0))
+            }
 
-                it("should return a value in degrees", closure: {
-                    let radians = Double.pi / 2.0
+            it("should return the angle in degrees") {
+                let radians = Double.pi / 2.0
 
-                    expect(radians.radiansToDegrees).to(equal(90.0))
-                })
+                expect(radians.radiansToDegrees).to(equal(90.0))
+            }
 
-                it("should return a value in degrees", closure: {
-                    let radians = Double.pi
+            it("should return the angle in degrees") {
+                let radians = Double.pi
 
-                    expect(radians.radiansToDegrees).to(equal(180.0))
-                })
+                expect(radians.radiansToDegrees).to(equal(180.0))
+            }
 
-                it("should return a value in degrees", closure: {
-                    let radians = Double.pi * 2.0
+            it("should return the angle in degrees") {
+                let radians = Double.pi * 2.0
 
-                    expect(radians.radiansToDegrees).to(equal(360.0))
-                })
-            })
-        })
+                expect(radians.radiansToDegrees).to(equal(360.0))
+            }
+        }
     }
 }

--- a/AurorKitTests/Extensions/NSLayoutConstraintTests.swift
+++ b/AurorKitTests/Extensions/NSLayoutConstraintTests.swift
@@ -20,28 +20,26 @@ class NSLayoutConstraintTests: QuickSpec {
     override func spec() {
         var view: UIView!
 
-        beforeEach({
+        beforeEach {
             view = UIView()
-        })
+        }
 
-        context("Instance Properties", {
-            describe(".preciseConstant", {
-                var constraint: NSLayoutConstraint!
+        describe(".preciseConstant") {
+            var constraint: NSLayoutConstraint!
 
-                beforeEach({
-                    constraint = view.widthAnchor.constraint(equalToConstant: 123.0)
-                })
+            beforeEach {
+                constraint = view.widthAnchor.constraint(equalToConstant: 123.0)
+            }
 
-                it("should return an properly constant", closure: {
-                    expect(constraint.preciseConstant).to(equal(Int(123.0 * UIScreen.main.scale)))
-                })
+            it("should return an properly constant") {
+                expect(constraint.preciseConstant).to(equal(Int(123.0 * UIScreen.main.scale)))
+            }
 
-                it("should set an properly constant", closure: {
-                    constraint.preciseConstant = 1
+            it("should set an properly constant") {
+                constraint.preciseConstant = 1
 
-                    expect(constraint.constant).to(equal(1.0 / UIScreen.main.scale))
-                })
-            })
-        })
+                expect(constraint.constant).to(equal(1.0 / UIScreen.main.scale))
+            }
+        }
     }
 }

--- a/AurorKitTests/Extensions/RangeReplaceableCollectionExtensionTests.swift
+++ b/AurorKitTests/Extensions/RangeReplaceableCollectionExtensionTests.swift
@@ -18,76 +18,74 @@ class RangeReplaceableCollectionExtensionTests: QuickSpec {
     // MARK: - Instance Methods
 
     override func spec() {
-        context("Instance Methods", {
-            describe(".removeFirst(where:)", {
-                it("should not change the array", closure: {
-                    var collection: [Int] = []
+        describe(".removeFirst(where:)") {
+            it("should not change the array") {
+                var collection: [Int] = []
 
-                    collection.removeFirst(where: { ($0 % 2) == 0 })
+                collection.removeFirst(where: { ($0 % 2) == 0 })
 
-                    expect(collection).to(equal([]))
-                })
+                expect(collection).to(equal([]))
+            }
 
-                it("should remove the first even number", closure: {
-                    var collection = [1, 2, 3, 4, 5]
+            it("should remove the first even number") {
+                var collection = [1, 2, 3, 4, 5]
 
-                    collection.removeFirst(where: { ($0 % 2) == 0 })
+                collection.removeFirst(where: { ($0 % 2) == 0 })
 
-                    expect(collection).to(equal([1, 3, 4, 5]))
-                })
+                expect(collection).to(equal([1, 3, 4, 5]))
+            }
 
-                it("should not change the array", closure: {
-                    var collection = [1, 3, 5, 7]
+            it("should not change the array") {
+                var collection = [1, 3, 5, 7]
 
-                    collection.removeFirst(where: { ($0 % 2) == 0 })
+                collection.removeFirst(where: { ($0 % 2) == 0 })
 
-                    expect(collection).to(equal([1, 3, 5, 7]))
-                })
-            })
+                expect(collection).to(equal([1, 3, 5, 7]))
+            }
+        }
 
-            describe(".prepend(contentsOf:)", {
-                it("should prepend elements to the collection", closure: {
-                    var collection: [Int] = []
+        describe(".prepend(contentsOf:)") {
+            it("should prepend elements to the collection") {
+                var collection: [Int] = []
 
-                    collection.prepend(contentsOf: [1, 2, 3])
+                collection.prepend(contentsOf: [1, 2, 3])
 
-                    expect(collection).to(equal([1, 2, 3]))
-                })
+                expect(collection).to(equal([1, 2, 3]))
+            }
 
-                it("should prepend elements to the collection", closure: {
-                    var collection = [4, 5, 6]
+            it("should prepend elements to the collection") {
+                var collection = [4, 5, 6]
 
-                    collection.prepend(contentsOf: [1, 2, 3])
+                collection.prepend(contentsOf: [1, 2, 3])
 
-                    expect(collection).to(equal([1, 2, 3, 4, 5, 6]))
-                })
+                expect(collection).to(equal([1, 2, 3, 4, 5, 6]))
+            }
 
-                it("should not change the array", closure: {
-                    var collection = [1, 2, 3]
+            it("should not change the array") {
+                var collection = [1, 2, 3]
 
-                    collection.prepend(contentsOf: [])
+                collection.prepend(contentsOf: [])
 
-                    expect(collection).to(equal([1, 2, 3]))
-                })
-            })
+                expect(collection).to(equal([1, 2, 3]))
+            }
+        }
 
-            describe(".prepend(:)", {
-                it("should prepend an element to the collection", closure: {
-                    var collection: [Int] = []
+        describe(".prepend(:)") {
+            it("should prepend an element to the collection") {
+                var collection: [Int] = []
 
-                    collection.prepend(123)
+                collection.prepend(123)
 
-                    expect(collection).to(equal([123]))
-                })
+                expect(collection).to(equal([123]))
+            }
 
-                it("should prepend an element to the collection", closure: {
-                    var collection = [4, 5, 6]
+            it("should prepend an element to the collection") {
+                var collection = [4, 5, 6]
 
-                    collection.prepend(123)
+                collection.prepend(123)
 
-                    expect(collection).to(equal([123, 4, 5, 6]))
-                })
-            })
-        })
+                expect(collection).to(equal([123, 4, 5, 6]))
+            }
+        }
     }
 }

--- a/AurorKitTests/Extensions/StringExtensionTests.swift
+++ b/AurorKitTests/Extensions/StringExtensionTests.swift
@@ -18,120 +18,118 @@ class StringExtensionTests: QuickSpec {
     // MARK: - Instance Methods
 
     override func spec() {
-        context("Instance Methods", {
-            describe(".localized(tableName:, comment:)", {
-                it("should return an empty string", closure: {
-                    let string = ""
+        describe(".localized(tableName:, comment:)") {
+            it("should return an empty string") {
+                let string = ""
 
-                    expect(string.localized(tableName: nil, comment: "")).to(beEmpty())
-                })
+                expect(string.localized(tableName: nil, comment: "")).to(beEmpty())
+            }
 
-                it("should return a non-localized string", closure: {
-                    let string = "String"
+            it("should return a non-localized string") {
+                let string = "String"
 
-                    expect(string.localized(tableName: nil, comment: "")).to(equal("String"))
-                })
-            })
+                expect(string.localized(tableName: nil, comment: "")).to(equal("String"))
+            }
+        }
 
-            describe(".prefix(count:)", {
-                it("should return an empty string", closure: {
-                    let string = ""
+        describe(".prefix(count:)") {
+            it("should return an empty string") {
+                let string = ""
 
-                    expect(string.prefix(count: -1)).to(beEmpty())
-                })
+                expect(string.prefix(count: -1)).to(beEmpty())
+            }
 
-                it("should return an empty string", closure: {
-                    let string = ""
+            it("should return an empty string") {
+                let string = ""
 
-                    expect(string.prefix(count: 0)).to(beEmpty())
-                })
+                expect(string.prefix(count: 0)).to(beEmpty())
+            }
 
-                it("should return an empty string", closure: {
-                    let string = ""
+            it("should return an empty string") {
+                let string = ""
 
-                    expect(string.prefix(count: 1)).to(beEmpty())
-                })
+                expect(string.prefix(count: 1)).to(beEmpty())
+            }
 
-                it("should return an empty string", closure: {
-                    let string = "123456"
+            it("should return an empty string") {
+                let string = "123456"
 
-                    expect(string.prefix(count: -1)).to(beEmpty())
-                })
+                expect(string.prefix(count: -1)).to(beEmpty())
+            }
 
-                it("should return an empty string", closure: {
-                    let string = "123456"
+            it("should return an empty string") {
+                let string = "123456"
 
-                    expect(string.prefix(count: 0)).to(beEmpty())
-                })
+                expect(string.prefix(count: 0)).to(beEmpty())
+            }
 
-                it("should return a string prefix", closure: {
-                    let string = "123456"
+            it("should return a string prefix") {
+                let string = "123456"
 
-                    expect(string.prefix(count: 5)).to(equal("12345"))
-                })
+                expect(string.prefix(count: 5)).to(equal("12345"))
+            }
 
-                it("should return a string prefix", closure: {
-                    let string = "123456"
+            it("should return a string prefix") {
+                let string = "123456"
 
-                    expect(string.prefix(count: 6)).to(equal("123456"))
-                })
+                expect(string.prefix(count: 6)).to(equal("123456"))
+            }
 
-                it("should return a string prefix", closure: {
-                    let string = "123456"
+            it("should return a string prefix") {
+                let string = "123456"
 
-                    expect(string.prefix(count: 7)).to(equal("123456"))
-                })
-            })
+                expect(string.prefix(count: 7)).to(equal("123456"))
+            }
+        }
 
-            describe(".suffix(count:)", {
-                it("should return an empty string", closure: {
-                    let string = ""
+        describe(".suffix(count:)") {
+            it("should return an empty string") {
+                let string = ""
 
-                    expect(string.suffix(from: -1)).to(beEmpty())
-                })
+                expect(string.suffix(from: -1)).to(beEmpty())
+            }
 
-                it("should return an empty string", closure: {
-                    let string = ""
+            it("should return an empty string") {
+                let string = ""
 
-                    expect(string.suffix(from: 0)).to(beEmpty())
-                })
+                expect(string.suffix(from: 0)).to(beEmpty())
+            }
 
-                it("should return an empty string", closure: {
-                    let string = ""
+            it("should return an empty string") {
+                let string = ""
 
-                    expect(string.suffix(from: 1)).to(beEmpty())
-                })
+                expect(string.suffix(from: 1)).to(beEmpty())
+            }
 
-                it("should return a string suffix", closure: {
-                    let string = "123456"
+            it("should return a string suffix") {
+                let string = "123456"
 
-                    expect(string.suffix(from: -1)).to(equal("123456"))
-                })
+                expect(string.suffix(from: -1)).to(equal("123456"))
+            }
 
-                it("should return a string suffix", closure: {
-                    let string = "123456"
+            it("should return a string suffix") {
+                let string = "123456"
 
-                    expect(string.suffix(from: 0)).to(equal("123456"))
-                })
+                expect(string.suffix(from: 0)).to(equal("123456"))
+            }
 
-                it("should return a string suffix", closure: {
-                    let string = "123456"
+            it("should return a string suffix") {
+                let string = "123456"
 
-                    expect(string.suffix(from: 5)).to(equal("6"))
-                })
+                expect(string.suffix(from: 5)).to(equal("6"))
+            }
 
-                it("should return a string suffix", closure: {
-                    let string = "123456"
+            it("should return a string suffix") {
+                let string = "123456"
 
-                    expect(string.suffix(from: 6)).to(beEmpty())
-                })
+                expect(string.suffix(from: 6)).to(beEmpty())
+            }
 
-                it("should return a string suffix", closure: {
-                    let string = "123456"
+            it("should return a string suffix") {
+                let string = "123456"
 
-                    expect(string.suffix(from: 7)).to(beEmpty())
-                })
-            })
-        })
+                expect(string.suffix(from: 7)).to(beEmpty())
+            }
+        }
     }
 }

--- a/AurorKitTests/Extensions/UIColorExtensionTests.swift
+++ b/AurorKitTests/Extensions/UIColorExtensionTests.swift
@@ -18,200 +18,388 @@ class UIColorExtensionTests: QuickSpec {
     // MARK: - Instance Methods
 
     override func spec() {
-        context("Initializers", {
-            describe(".init(red:, green:, blue:)", {
-                it("should initialize properly", closure: {
-                    let color = UIColor(red: 0.0, green: 0.123, blue: 1.0)
+        describe(".init(red:, green:, blue:)") {
+            it("should initialize properly") {
+                let color = UIColor(red: 0.0, green: 0.123, blue: 1.0)
 
-                    expect(color).to(equal(UIColor(red: 0.0, green: 0.123, blue: 1.0, alpha: 1.0)))
-                })
-            })
+                expect(color).to(equal(UIColor(red: 0.0, green: 0.123, blue: 1.0, alpha: 1.0)))
+            }
+        }
 
-            describe(".init(white:)", {
-                it("should initialize properly", closure: {
-                    let color = UIColor(white: 0.0)
+        describe(".init(white:)") {
+            it("should initialize properly") {
+                let color = UIColor(white: 0.0)
 
-                    expect(color).to(equal(UIColor(white: 0.0, alpha: 1.0)))
-                })
+                expect(color).to(equal(UIColor(white: 0.0, alpha: 1.0)))
+            }
 
-                it("should initialize properly", closure: {
-                    let color = UIColor(white: 0.123)
+            it("should initialize properly") {
+                let color = UIColor(white: 0.123)
 
-                    expect(color).to(equal(UIColor(white: 0.123, alpha: 1.0)))
-                })
+                expect(color).to(equal(UIColor(white: 0.123, alpha: 1.0)))
+            }
 
-                it("should initialize properly", closure: {
-                    let color = UIColor(white: 1.0)
+            it("should initialize properly") {
+                let color = UIColor(white: 1.0)
 
-                    expect(color).to(equal(UIColor(white: 1.0, alpha: 1.0)))
-                })
-            })
+                expect(color).to(equal(UIColor(white: 1.0, alpha: 1.0)))
+            }
+        }
 
-            describe(".init(redByte:, greenByte:, blueByte:, alphaByte:)", {
-                it("should initialize properly", closure: {
-                    let color = UIColor(redByte: 0, greenByte: 123, blueByte: 255, alphaByte: 255)
+        describe(".init(redByte:, greenByte:, blueByte:, alphaByte:)") {
+            it("should initialize properly") {
+                let color = UIColor(redByte: 0, greenByte: 123, blueByte: 255, alphaByte: 255)
 
-                    expect(color).to(equal(UIColor(red: 0.0, green: 123.0 / 255.0, blue: 1.0, alpha: 1.0)))
-                })
-            })
+                expect(color).to(equal(UIColor(red: 0.0, green: 123.0 / 255.0, blue: 1.0, alpha: 1.0)))
+            }
+        }
 
-            describe(".init(redByte:, greenByte:, blueByte:, alpha:)", {
-                it("should initialize properly", closure: {
-                    let color = UIColor(redByte: 0, greenByte: 123, blueByte: 255, alpha: 0.123)
+        describe(".init(redByte:, greenByte:, blueByte:, alpha:)") {
+            it("should initialize properly") {
+                let color = UIColor(redByte: 0, greenByte: 123, blueByte: 255, alpha: 0.123)
 
-                    expect(color).to(equal(UIColor(red: 0.0, green: 123.0 / 255.0, blue: 1.0, alpha: 0.123)))
-                })
+                expect(color).to(equal(UIColor(red: 0.0, green: 123.0 / 255.0, blue: 1.0, alpha: 0.123)))
+            }
 
-                it("should initialize properly", closure: {
-                    let color = UIColor(redByte: 0, greenByte: 123, blueByte: 255)
+            it("should initialize properly") {
+                let color = UIColor(redByte: 0, greenByte: 123, blueByte: 255)
 
-                    expect(color).to(equal(UIColor(red: 0.0, green: 123.0 / 255.0, blue: 1.0, alpha: 1.0)))
-                })
-            })
+                expect(color).to(equal(UIColor(red: 0.0, green: 123.0 / 255.0, blue: 1.0, alpha: 1.0)))
+            }
+        }
 
-            describe(".init(whiteByte:, alphaByte:)", {
-                it("should initialize properly", closure: {
-                    let color = UIColor(whiteByte: 0, alphaByte: 0)
+        describe(".init(whiteByte:, alphaByte:)") {
+            it("should initialize properly") {
+                let color = UIColor(whiteByte: 0, alphaByte: 0)
 
-                    expect(color).to(equal(UIColor(white: 0.0, alpha: 0.0)))
-                })
+                expect(color).to(equal(UIColor(white: 0.0, alpha: 0.0)))
+            }
 
-                it("should initialize properly", closure: {
-                    let color = UIColor(whiteByte: 123, alphaByte: 123)
+            it("should initialize properly") {
+                let color = UIColor(whiteByte: 123, alphaByte: 123)
 
-                    expect(color).to(equal(UIColor(white: 123.0 / 255.0, alpha: 123.0 / 255.0)))
-                })
+                expect(color).to(equal(UIColor(white: 123.0 / 255.0, alpha: 123.0 / 255.0)))
+            }
 
-                it("should initialize properly", closure: {
-                    let color = UIColor(whiteByte: 255, alphaByte: 255)
+            it("should initialize properly") {
+                let color = UIColor(whiteByte: 255, alphaByte: 255)
 
-                    expect(color).to(equal(UIColor(white: 1.0, alpha: 1.0)))
-                })
-            })
+                expect(color).to(equal(UIColor(white: 1.0, alpha: 1.0)))
+            }
+        }
 
-            describe(".init(whiteByte:, alpha:)", {
-                it("should initialize properly", closure: {
-                    let color = UIColor(whiteByte: 0, alpha: 0.0)
+        describe(".init(whiteByte:, alpha:)") {
+            it("should initialize properly") {
+                let color = UIColor(whiteByte: 0, alpha: 0.0)
 
-                    expect(color).to(equal(UIColor(white: 0.0, alpha: 0.0)))
-                })
+                expect(color).to(equal(UIColor(white: 0.0, alpha: 0.0)))
+            }
 
-                it("should initialize properly", closure: {
-                    let color = UIColor(whiteByte: 123, alpha: 0.123)
+            it("should initialize properly") {
+                let color = UIColor(whiteByte: 123, alpha: 0.123)
 
-                    expect(color).to(equal(UIColor(white: 123.0 / 255.0, alpha: 0.123)))
-                })
+                expect(color).to(equal(UIColor(white: 123.0 / 255.0, alpha: 0.123)))
+            }
 
-                it("should initialize properly", closure: {
-                    let color = UIColor(whiteByte: 255, alpha: 1.0)
+            it("should initialize properly") {
+                let color = UIColor(whiteByte: 255, alpha: 1.0)
 
-                    expect(color).to(equal(UIColor(white: 1.0, alpha: 1.0)))
-                })
-            })
+                expect(color).to(equal(UIColor(white: 1.0, alpha: 1.0)))
+            }
+        }
 
-            describe(".init(argbHEX:)", {
-                it("should initialize properly", closure: {
-                    let color = UIColor(argbHEX: 0x12345678)
+        describe(".init(argbHexString:)") {
+            it("should initialize properly") {
+                let color = UIColor(argbHexString: "#12345678")
 
-                    expect(color).to(equal(UIColor(red: 52.0 / 255.0,
-                                                   green: 86.0 / 255.0,
-                                                   blue: 120.0 / 255.0,
-                                                   alpha: 18.0 / 255.0)))
-                })
-            })
+                expect(color).to(equal(UIColor(red: 52.0 / 255.0,
+                                               green: 86.0 / 255.0,
+                                               blue: 120.0 / 255.0,
+                                               alpha: 18.0 / 255.0)))
+            }
 
-            describe(".init(rgbHEX:)", {
-                it("should initialize properly", closure: {
-                    let color = UIColor(rgbHEX: 0x123456)
+            it("should initialize properly") {
+                let color = UIColor(argbHexString: "#1234")
 
-                    expect(color).to(equal(UIColor(red: 18.0 / 255.0,
-                                                   green: 52.0 / 255.0,
-                                                   blue: 86.0 / 255.0,
-                                                   alpha: 1.0)))
-                })
-            })
-        })
+                expect(color).to(equal(UIColor(red: 0.0,
+                                               green: 18.0 / 255.0,
+                                               blue: 52.0 / 255.0,
+                                               alpha: 0.0)))
+            }
 
-        context("Instance Properties", {
-            describe(".argbHEXString", {
-                it("should return the color as a HEX string", closure: {
-                    let color = UIColor(red: 0.0, green: 0.12, blue: 0.34, alpha: 1.0)
+            it("should not be initialized") {
+                let color = UIColor(argbHexString: "%12345678")
 
-                    expect(color.argbHEXString).to(equal("#FF001E56"))
-                })
+                expect(color).to(beNil())
+            }
 
-                it("should return the color as a HEX string", closure: {
-                    let color = UIColor(red: 0.12, green: 0.34, blue: 0.56, alpha: 0.0)
+            it("should not be initialized") {
+                let color = UIColor(argbHexString: "#qwerty")
 
-                    expect(color.argbHEXString).to(equal("#001E568E"))
-                })
+                expect(color).to(beNil())
+            }
+        }
 
-                it("should return the color as a HEX string", closure: {
-                    let color = UIColor(red: 0.0, green: 0.12, blue: 1.0, alpha: 0.34)
+        describe(".init(rgbaHexString:)") {
+            it("should initialize properly") {
+                let color = UIColor(rgbaHexString: "#12345678")
 
-                    expect(color.argbHEXString).to(equal("#56001EFF"))
-                })
-            })
+                expect(color).to(equal(UIColor(red: 18.0 / 255.0,
+                                               green: 52.0 / 255.0,
+                                               blue: 86.0 / 255.0,
+                                               alpha: 120.0 / 255.0)))
+            }
 
-            describe(".rgbaHEXString", {
-                it("should return the color as a HEX string", closure: {
-                    let color = UIColor(red: 0.0, green: 0.12, blue: 0.34, alpha: 1.0)
+            it("should initialize properly") {
+                let color = UIColor(rgbaHexString: "#1234")
 
-                    expect(color.rgbaHEXString).to(equal("#001E56FF"))
-                })
+                expect(color).to(equal(UIColor(red: 0.0,
+                                               green: 0.0,
+                                               blue: 18.0 / 255.0,
+                                               alpha: 52.0 / 255.0)))
+            }
 
-                it("should return the color as a HEX string", closure: {
-                    let color = UIColor(red: 0.12, green: 0.34, blue: 0.56, alpha: 0.0)
+            it("should not be initialized") {
+                let color = UIColor(rgbaHexString: "%12345678")
 
-                    expect(color.rgbaHEXString).to(equal("#1E568E00"))
-                })
+                expect(color).to(beNil())
+            }
 
-                it("should return the color as a HEX string", closure: {
-                    let color = UIColor(red: 0.0, green: 0.12, blue: 1.0, alpha: 0.34)
+            it("should not be initialized") {
+                let color = UIColor(rgbaHexString: "#qwerty")
 
-                    expect(color.rgbaHEXString).to(equal("#001EFF56"))
-                })
-            })
+                expect(color).to(beNil())
+            }
+        }
 
-            describe(".argbHEX", {
-                it("should return the color as a HEX number", closure: {
-                    let color = UIColor(red: 0.0, green: 0.12, blue: 0.34, alpha: 1.0)
+        describe(".init(rgbHexString:)") {
+            it("should initialize properly") {
+                let color = UIColor(rgbHexString: "#12345678")
 
-                    expect(color.argbHEX).to(equal(0xFF001E56))
-                })
+                expect(color).to(equal(UIColor(red: 52.0 / 255.0,
+                                               green: 86.0 / 255.0,
+                                               blue: 120.0 / 255.0,
+                                               alpha: 1.0)))
+            }
 
-                it("should return the color as a HEX number", closure: {
-                    let color = UIColor(red: 0.12, green: 0.34, blue: 0.56, alpha: 0.0)
+            it("should initialize properly") {
+                let color = UIColor(rgbHexString: "#123456")
 
-                    expect(color.argbHEX).to(equal(0x001E568E))
-                })
+                expect(color).to(equal(UIColor(red: 18.0 / 255.0,
+                                               green: 52.0 / 255.0,
+                                               blue: 86.0 / 255.0,
+                                               alpha: 1.0)))
+            }
 
-                it("should return the color as a HEX number", closure: {
-                    let color = UIColor(red: 0.0, green: 0.12, blue: 1.0, alpha: 0.34)
+            it("should initialize properly") {
+                let color = UIColor(rgbHexString: "#1234")
 
-                    expect(color.argbHEX).to(equal(0x56001EFF))
-                })
-            })
+                expect(color).to(equal(UIColor(red: 0.0,
+                                               green: 18.0 / 255.0,
+                                               blue: 52.0 / 255.0,
+                                               alpha: 1.0)))
+            }
 
-            describe(".rgbaHEX", {
-                it("should return the color as a HEX number", closure: {
-                    let color = UIColor(red: 0.0, green: 0.12, blue: 0.34, alpha: 1.0)
+            it("should not be initialized") {
+                let color = UIColor(rgbHexString: "%12345678")
 
-                    expect(color.rgbaHEX).to(equal(0x001E56FF))
-                })
+                expect(color).to(beNil())
+            }
 
-                it("should return the color as a HEX number", closure: {
-                    let color = UIColor(red: 0.12, green: 0.34, blue: 0.56, alpha: 0.0)
+            it("should not be initialized") {
+                let color = UIColor(rgbHexString: "#qwerty")
 
-                    expect(color.rgbaHEX).to(equal(0x1E568E00))
-                })
+                expect(color).to(beNil())
+            }
+        }
 
-                it("should return the color as a HEX number", closure: {
-                    let color = UIColor(red: 0.0, green: 0.12, blue: 1.0, alpha: 0.34)
+        describe(".init(argbHex:)") {
+            it("should initialize properly") {
+                let color = UIColor(argbHex: 0x12345678)
 
-                    expect(color.rgbaHEX).to(equal(0x001EFF56))
-                })
-            })
-        })
+                expect(color).to(equal(UIColor(red: 52.0 / 255.0,
+                                               green: 86.0 / 255.0,
+                                               blue: 120.0 / 255.0,
+                                               alpha: 18.0 / 255.0)))
+            }
+
+            it("should initialize properly") {
+                let color = UIColor(argbHex: 0x1234)
+
+                expect(color).to(equal(UIColor(red: 0.0,
+                                               green: 18.0 / 255.0,
+                                               blue: 52.0 / 255.0,
+                                               alpha: 0.0)))
+            }
+        }
+
+        describe(".init(rgbaHex:)") {
+            it("should initialize properly") {
+                let color = UIColor(rgbaHex: 0x12345678)
+
+                expect(color).to(equal(UIColor(red: 18.0 / 255.0,
+                                               green: 52.0 / 255.0,
+                                               blue: 86.0 / 255.0,
+                                               alpha: 120.0 / 255.0)))
+            }
+
+            it("should initialize properly") {
+                let color = UIColor(rgbaHex: 0x1234)
+
+                expect(color).to(equal(UIColor(red: 0.0,
+                                               green: 0.0,
+                                               blue: 18.0 / 255.0,
+                                               alpha: 52.0 / 255.0)))
+            }
+        }
+
+        describe(".init(rgbHex:)") {
+            it("should initialize properly") {
+                let color = UIColor(rgbHex: 0x12345678)
+
+                expect(color).to(equal(UIColor(red: 52.0 / 255.0,
+                                               green: 86.0 / 255.0,
+                                               blue: 120.0 / 255.0,
+                                               alpha: 1.0)))
+            }
+
+            it("should initialize properly") {
+                let color = UIColor(rgbHex: 0x123456)
+
+                expect(color).to(equal(UIColor(red: 18.0 / 255.0,
+                                               green: 52.0 / 255.0,
+                                               blue: 86.0 / 255.0,
+                                               alpha: 1.0)))
+            }
+
+            it("should initialize properly") {
+                let color = UIColor(rgbHex: 0x1234)
+
+                expect(color).to(equal(UIColor(red: 0.0,
+                                               green: 18.0 / 255.0,
+                                               blue: 52.0 / 255.0,
+                                               alpha: 1.0)))
+            }
+        }
+
+        describe(".argbHexString") {
+            it("should return the color as hex string") {
+                let color = UIColor(red: 0.0, green: 0.12, blue: 0.34, alpha: 1.0)
+
+                expect(color.argbHexString).to(equal("#FF001E56"))
+            }
+
+            it("should return the color as hex string") {
+                let color = UIColor(red: 0.12, green: 0.34, blue: 0.56, alpha: 0.0)
+
+                expect(color.argbHexString).to(equal("#001E568E"))
+            }
+
+            it("should return the color as hex string") {
+                let color = UIColor(red: 0.0, green: 0.12, blue: 1.0, alpha: 0.34)
+
+                expect(color.argbHexString).to(equal("#56001EFF"))
+            }
+        }
+
+        describe(".rgbaHexString") {
+            it("should return the color as hex string") {
+                let color = UIColor(red: 0.0, green: 0.12, blue: 0.34, alpha: 1.0)
+
+                expect(color.rgbaHexString).to(equal("#001E56FF"))
+            }
+
+            it("should return the color as hex string") {
+                let color = UIColor(red: 0.12, green: 0.34, blue: 0.56, alpha: 0.0)
+
+                expect(color.rgbaHexString).to(equal("#1E568E00"))
+            }
+
+            it("should return the color as hex string") {
+                let color = UIColor(red: 0.0, green: 0.12, blue: 1.0, alpha: 0.34)
+
+                expect(color.rgbaHexString).to(equal("#001EFF56"))
+            }
+        }
+
+        describe(".rgbHexString") {
+            it("should return the color as hex string") {
+                let color = UIColor(red: 0.0, green: 0.12, blue: 0.34, alpha: 1.0)
+
+                expect(color.rgbHexString).to(equal("#001E56"))
+            }
+
+            it("should return the color as hex string") {
+                let color = UIColor(red: 0.12, green: 0.34, blue: 0.56, alpha: 0.0)
+
+                expect(color.rgbHexString).to(equal("#1E568E"))
+            }
+
+            it("should return the color as hex string") {
+                let color = UIColor(red: 0.0, green: 0.12, blue: 1.0, alpha: 0.34)
+
+                expect(color.rgbHexString).to(equal("#001EFF"))
+            }
+        }
+
+        describe(".argbHex") {
+            it("should return the color as hex number") {
+                let color = UIColor(red: 0.0, green: 0.12, blue: 0.34, alpha: 1.0)
+
+                expect(color.argbHex).to(equal(0xFF001E56))
+            }
+
+            it("should return the color as hex number") {
+                let color = UIColor(red: 0.12, green: 0.34, blue: 0.56, alpha: 0.0)
+
+                expect(color.argbHex).to(equal(0x001E568E))
+            }
+
+            it("should return the color as hex number") {
+                let color = UIColor(red: 0.0, green: 0.12, blue: 1.0, alpha: 0.34)
+
+                expect(color.argbHex).to(equal(0x56001EFF))
+            }
+        }
+
+        describe(".rgbaHex") {
+            it("should return the color as hex number") {
+                let color = UIColor(red: 0.0, green: 0.12, blue: 0.34, alpha: 1.0)
+
+                expect(color.rgbaHex).to(equal(0x001E56FF))
+            }
+
+            it("should return the color as hex number") {
+                let color = UIColor(red: 0.12, green: 0.34, blue: 0.56, alpha: 0.0)
+
+                expect(color.rgbaHex).to(equal(0x1E568E00))
+            }
+
+            it("should return the color as hex number") {
+                let color = UIColor(red: 0.0, green: 0.12, blue: 1.0, alpha: 0.34)
+
+                expect(color.rgbaHex).to(equal(0x001EFF56))
+            }
+        }
+
+        describe(".rgbHex") {
+            it("should return the color as hex number") {
+                let color = UIColor(red: 0.0, green: 0.12, blue: 0.34, alpha: 1.0)
+
+                expect(color.rgbHex).to(equal(0x001E56))
+            }
+
+            it("should return the color as hex number") {
+                let color = UIColor(red: 0.12, green: 0.34, blue: 0.56, alpha: 0.0)
+
+                expect(color.rgbHex).to(equal(0x1E568E))
+            }
+
+            it("should return the color as hex number") {
+                let color = UIColor(red: 0.0, green: 0.12, blue: 1.0, alpha: 0.34)
+
+                expect(color.rgbHex).to(equal(0x001EFF))
+            }
+        }
     }
 }

--- a/AurorKitTests/Extensions/UIEdgeInsetsExtensionTests.swift
+++ b/AurorKitTests/Extensions/UIEdgeInsetsExtensionTests.swift
@@ -18,17 +18,15 @@ class UIEdgeInsetsExtensionTests: QuickSpec {
     // MARK: - Instance Methods
 
     override func spec() {
-        context("Initializers", {
-            describe(".init(equilateral:)", {
-                it("should initialize properly", closure: {
-                    let edgeInsets = UIEdgeInsets(equilateral: 1.23)
+        describe(".init(equilateral:)") {
+            it("should initialize properly") {
+                let edgeInsets = UIEdgeInsets(equilateral: 1.23)
 
-                    expect(edgeInsets.top).to(equal(1.23))
-                    expect(edgeInsets.left).to(equal(1.23))
-                    expect(edgeInsets.bottom).to(equal(1.23))
-                    expect(edgeInsets.right).to(equal(1.23))
-                })
-            })
-        })
+                expect(edgeInsets.top).to(equal(1.23))
+                expect(edgeInsets.left).to(equal(1.23))
+                expect(edgeInsets.bottom).to(equal(1.23))
+                expect(edgeInsets.right).to(equal(1.23))
+            }
+        }
     }
 }

--- a/AurorKitTests/Extensions/UIImageExtensionTests.swift
+++ b/AurorKitTests/Extensions/UIImageExtensionTests.swift
@@ -18,84 +18,144 @@ class UIImageExtensionTests: QuickSpec {
     // MARK: - Instance Methods
 
     override func spec() {
-        context("Instance Methods", {
-            describe(".scaled(to:)", {
-                it("should return nil", closure: {
-                    let image = UIImage().scaled(to: CGSize(width: 0, height: 0))
+        describe(".alignmentRect") {
+            context("when image has zero size") {
+                var image: UIImage!
 
-                    expect(image).to(beNil())
-                })
+                beforeEach {
+                    image = UIImage()
+                }
 
-                it("should return nil", closure: {
-                    let image = UIImage().scaled(to: CGSize(width: 123, height: 0))
+                it("should return a zero rectangle") {
+                    expect(image.alignmentRect).to(equal(.zero))
+                }
 
-                    expect(image).to(beNil())
-                })
+                it("should return a zero rectangle") {
+                    let image = image.withAlignmentRectInsets(UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0))
 
-                it("should return nil", closure: {
-                    let image = UIImage().scaled(to: CGSize(width: 0, height: 123))
+                    expect(image.alignmentRect).to(equal(.zero))
+                }
 
-                    expect(image).to(beNil())
-                })
+                it("should return the correct rectangle") {
+                    let image = image.withAlignmentRectInsets(UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4))
 
-                it("should return a properly scaled image", closure: {
-                    let image = UIImage().scaled(to: CGSize(width: 123, height: 456))
+                    expect(image.alignmentRect).to(equal(CGRect(x: 2, y: 1, width: -6, height: -4)))
+                }
 
-                    expect(image?.size).to(equal(CGSize(width: 123, height: 456)))
-                })
-            })
+                it("should return the correct rectangle") {
+                    let image = image.withAlignmentRectInsets(UIEdgeInsets(top: -1, left: -2, bottom: -3, right: -4))
 
-            describe(".scaledToWidth(:)", {
-                it("should return nil", closure: {
-                    let image = UIImage().scaledToWidth(0.0)
+                    expect(image.alignmentRect).to(equal(CGRect(x: -2, y: -1, width: 6, height: 4)))
+                }
+            }
 
-                    expect(image).to(beNil())
-                })
+            context("when image has non-zero size") {
+                var image: UIImage!
 
-                it("should return a properly scaled image", closure: {
-                    let image = UIImage().scaledToWidth(123)
+                beforeEach {
+                    image = UIImage().scaled(to: CGSize(width: 123, height: 456))
+                }
 
-                    expect(image?.size).to(equal(CGSize(width: 123, height: 123)))
-                })
+                it("should return the correct rectangle") {
+                    expect(image.alignmentRect).to(equal(CGRect(x: 0, y: 0, width: 123, height: 456)))
+                }
 
-                it("should return nil", closure: {
-                    let image = UIImage().scaled(to: CGSize(width: 12, height: 34))?.scaledToWidth(0)
+                it("should return the correct rectangle") {
+                    let image = image.withAlignmentRectInsets(UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0))
 
-                    expect(image).to(beNil())
-                })
+                    expect(image.alignmentRect).to(equal(CGRect(x: 0, y: 0, width: 123, height: 456)))
+                }
 
-                it("should return a properly scaled image", closure: {
-                    let image = UIImage().scaled(to: CGSize(width: 12, height: 34))?.scaledToWidth(24)
+                it("should return the correct rectangle") {
+                    let image = image.withAlignmentRectInsets(UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4))
 
-                    expect(image?.size).to(equal(CGSize(width: 24, height: 68)))
-                })
-            })
+                    expect(image.alignmentRect).to(equal(CGRect(x: 2, y: 1, width: 117, height: 452)))
+                }
 
-            describe(".scaledToHeight(:)", {
-                it("should return nil", closure: {
-                    let image = UIImage().scaledToHeight(0.0)
+                it("should return the correct rectangle") {
+                    let image = image.withAlignmentRectInsets(UIEdgeInsets(top: -1, left: -2, bottom: -3, right: -4))
 
-                    expect(image).to(beNil())
-                })
+                    expect(image.alignmentRect).to(equal(CGRect(x: -2, y: -1, width: 129, height: 460)))
+                }
+            }
+        }
 
-                it("should return a properly scaled image", closure: {
-                    let image = UIImage().scaledToHeight(123)
+        describe(".scaled(to:)") {
+            it("should return nil") {
+                let image = UIImage().scaled(to: CGSize(width: 0, height: 0))
 
-                    expect(image?.size).to(equal(CGSize(width: 123, height: 123)))
-                })
+                expect(image).to(beNil())
+            }
 
-                it("should return nil", closure: {
-                    let image = UIImage().scaled(to: CGSize(width: 12, height: 34))?.scaledToHeight(0)
+            it("should return nil") {
+                let image = UIImage().scaled(to: CGSize(width: 123, height: 0))
 
-                    expect(image).to(beNil())
-                })
+                expect(image).to(beNil())
+            }
 
-                it("should return a properly scaled image", closure: {
-                    let image = UIImage().scaled(to: CGSize(width: 12, height: 34))?.scaledToHeight(17)
+            it("should return nil") {
+                let image = UIImage().scaled(to: CGSize(width: 0, height: 123))
 
-                    expect(image?.size).to(equal(CGSize(width: 6, height: 17)))
-                })
-            })
-        })
+                expect(image).to(beNil())
+            }
+
+            it("should return a properly scaled image") {
+                let image = UIImage().scaled(to: CGSize(width: 123, height: 456))
+
+                expect(image?.size).to(equal(CGSize(width: 123, height: 456)))
+            }
+        }
+
+        describe(".scaledToWidth(:)") {
+            it("should return nil") {
+                let image = UIImage().scaledToWidth(0.0)
+
+                expect(image).to(beNil())
+            }
+
+            it("should return a properly scaled image") {
+                let image = UIImage().scaledToWidth(123)
+
+                expect(image?.size).to(equal(CGSize(width: 123, height: 123)))
+            }
+
+            it("should return nil") {
+                let image = UIImage().scaled(to: CGSize(width: 12, height: 34))?.scaledToWidth(0)
+
+                expect(image).to(beNil())
+            }
+
+            it("should return a properly scaled image") {
+                let image = UIImage().scaled(to: CGSize(width: 12, height: 34))?.scaledToWidth(24)
+
+                expect(image?.size).to(equal(CGSize(width: 24, height: 68)))
+            }
+        }
+
+        describe(".scaledToHeight(:)") {
+            it("should return nil") {
+                let image = UIImage().scaledToHeight(0.0)
+
+                expect(image).to(beNil())
+            }
+
+            it("should return a properly scaled image") {
+                let image = UIImage().scaledToHeight(123)
+
+                expect(image?.size).to(equal(CGSize(width: 123, height: 123)))
+            }
+
+            it("should return nil") {
+                let image = UIImage().scaled(to: CGSize(width: 12, height: 34))?.scaledToHeight(0)
+
+                expect(image).to(beNil())
+            }
+
+            it("should return a properly scaled image") {
+                let image = UIImage().scaled(to: CGSize(width: 12, height: 34))?.scaledToHeight(17)
+
+                expect(image?.size).to(equal(CGSize(width: 6, height: 17)))
+            }
+        }
     }
 }

--- a/AurorKitTests/Extensions/UIViewBorderExtensionTests.swift
+++ b/AurorKitTests/Extensions/UIViewBorderExtensionTests.swift
@@ -1,0 +1,53 @@
+//
+//  UIViewBorderExtensionTests.swift
+//  AurorKit
+//
+//  Created by Almaz Ibragimov on 13/02/2019.
+//  Copyright © 2019 Aurors. All rights reserved.
+//
+
+import UIKit
+
+import Quick
+import Nimble
+
+@testable import AurorKit
+
+class UIViewBorderExtensionTests: QuickSpec {
+
+    // MARK: - Instance Methods
+
+    override func spec() {
+        var view: UIView!
+
+        beforeEach {
+            view = UIView()
+        }
+
+        describe(".border") {
+            it("should return an empty border") {
+                expect(view.border.width).to(equal(UIView.Border.empty.width))
+                expect(view.border.color).to(equalColor(UIView.Border.empty.color))
+            }
+
+            it("should return the correct border") {
+                expect(view.border.width).to(equal(view.layer.borderWidth))
+                expect(view.border.color?.cgColor).to(equal(view.layer.borderColor))
+            }
+
+            it("should set border properly") {
+                view.border = UIView.Border(width: 1.23, color: UIColor(red: 0.12, green: 0.34, blue: 0.56))
+
+                expect(view.layer.borderWidth).to(equal(1.23))
+                expect(view.layer.borderColor).to(equal(UIColor(red: 0.12, green: 0.34, blue: 0.56).cgColor))
+            }
+
+            it("should set border properly") {
+                view.border = UIView.Border(width: 0.0, color: nil)
+
+                expect(view.layer.borderWidth).to(equal(0.0))
+                expect(view.layer.borderColor).to(beNil())
+            }
+        }
+    }
+}

--- a/AurorKitTests/Extensions/UIViewControllerExtensionTests.swift
+++ b/AurorKitTests/Extensions/UIViewControllerExtensionTests.swift
@@ -1,0 +1,59 @@
+//
+//  UIViewControllerExtensionTests.swift
+//  AurorKit
+//
+//  Created by Almaz Ibragimov on 13/02/2019.
+//  Copyright © 2019 Aurors. All rights reserved.
+//
+
+import UIKit
+
+import Quick
+import Nimble
+
+@testable import AurorKit
+
+class UIViewControllerExtensionTests: QuickSpec {
+
+    // MARK: - Instance Methods
+
+    override func spec() {
+        var window: UIWindow!
+        var viewController: UIViewController!
+
+        beforeEach {
+            window = UIWindow(frame: UIScreen.main.bounds)
+            viewController = UIViewController()
+        }
+
+        describe(".isVisible") {
+            context("when window has no root view controller") {
+                it("should be invisible") {
+                    expect(viewController.isVisible).to(beFalse())
+                }
+            }
+
+            context("when window has root view controller") {
+                beforeEach {
+                    window.rootViewController = viewController
+
+                    viewController.loadViewIfNeeded()
+                }
+
+                it("should return invisible") {
+                    expect(viewController.isVisible).toEventuallyNot(beTrue())
+                }
+
+                context("when window is visible") {
+                    beforeEach {
+                        window.isHidden = false
+                    }
+
+                    it("should be invisible") {
+                        expect(viewController.isVisible).toEventuallyNot(beFalse())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AurorKitTests/Extensions/UIViewExtensionTests.swift
+++ b/AurorKitTests/Extensions/UIViewExtensionTests.swift
@@ -20,106 +20,104 @@ class UIViewExtensionTests: QuickSpec {
     override func spec() {
         var view: UIView!
 
-        beforeEach({
+        beforeEach {
             view = UIView()
-        })
+        }
 
-        context("Instance Properties", {
-            describe(".safeAreaLeadingAnchor", {
-                it("should return the leading anchor", closure: {
-                    let leadingAnchor = view.safeAreaLeadingAnchor
+        describe(".safeAreaLeadingAnchor") {
+            it("should return the leading anchor") {
+                let leadingAnchor = view.safeAreaLeadingAnchor
 
-                    if #available(iOS 11.0, tvOS 11.0, *) {
-                        expect(leadingAnchor).to(beIdenticalTo(view.safeAreaLayoutGuide.leadingAnchor))
-                    } else {
-                        expect(leadingAnchor).to(beIdenticalTo(view.leadingAnchor))
-                    }
-                })
-            })
+                if #available(iOS 11.0, tvOS 11.0, *) {
+                    expect(leadingAnchor).to(beIdenticalTo(view.safeAreaLayoutGuide.leadingAnchor))
+                } else {
+                    expect(leadingAnchor).to(beIdenticalTo(view.leadingAnchor))
+                }
+            }
+        }
 
-            describe(".safeAreaTrailingAnchor", {
-                it("should return the trailing anchor", closure: {
-                    let trailingAnchor = view.safeAreaTrailingAnchor
+        describe(".safeAreaTrailingAnchor") {
+            it("should return the trailing anchor") {
+                let trailingAnchor = view.safeAreaTrailingAnchor
 
-                    if #available(iOS 11.0, tvOS 11.0, *) {
-                        expect(trailingAnchor).to(beIdenticalTo(view.safeAreaLayoutGuide.trailingAnchor))
-                    } else {
-                        expect(trailingAnchor).to(beIdenticalTo(view.trailingAnchor))
-                    }
-                })
-            })
+                if #available(iOS 11.0, tvOS 11.0, *) {
+                    expect(trailingAnchor).to(beIdenticalTo(view.safeAreaLayoutGuide.trailingAnchor))
+                } else {
+                    expect(trailingAnchor).to(beIdenticalTo(view.trailingAnchor))
+                }
+            }
+        }
 
-            describe(".safeAreaTopAnchor", {
-                it("should return the top anchor", closure: {
-                    let topAnchor = view.safeAreaTopAnchor
+        describe(".safeAreaTopAnchor") {
+            it("should return the top anchor") {
+                let topAnchor = view.safeAreaTopAnchor
 
-                    if #available(iOS 11.0, tvOS 11.0, *) {
-                        expect(topAnchor).to(beIdenticalTo(view.safeAreaLayoutGuide.topAnchor))
-                    } else {
-                        expect(topAnchor).to(beIdenticalTo(view.topAnchor))
-                    }
-                })
-            })
+                if #available(iOS 11.0, tvOS 11.0, *) {
+                    expect(topAnchor).to(beIdenticalTo(view.safeAreaLayoutGuide.topAnchor))
+                } else {
+                    expect(topAnchor).to(beIdenticalTo(view.topAnchor))
+                }
+            }
+        }
 
-            describe(".safeAreaBottomAnchor", {
-                it("should return the bottom anchor", closure: {
-                    let bottomAnchor = view.safeAreaBottomAnchor
+        describe(".safeAreaBottomAnchor") {
+            it("should return the bottom anchor") {
+                let bottomAnchor = view.safeAreaBottomAnchor
 
-                    if #available(iOS 11.0, tvOS 11.0, *) {
-                        expect(bottomAnchor).to(beIdenticalTo(view.safeAreaLayoutGuide.bottomAnchor))
-                    } else {
-                        expect(bottomAnchor).to(beIdenticalTo(view.bottomAnchor))
-                    }
-                })
-            })
+                if #available(iOS 11.0, tvOS 11.0, *) {
+                    expect(bottomAnchor).to(beIdenticalTo(view.safeAreaLayoutGuide.bottomAnchor))
+                } else {
+                    expect(bottomAnchor).to(beIdenticalTo(view.bottomAnchor))
+                }
+            }
+        }
 
-            describe(".safeAreaWidthAnchor", {
-                it("should return the width anchor", closure: {
-                    let widthAnchor = view.safeAreaWidthAnchor
+        describe(".safeAreaWidthAnchor") {
+            it("should return the width anchor") {
+                let widthAnchor = view.safeAreaWidthAnchor
 
-                    if #available(iOS 11.0, tvOS 11.0, *) {
-                        expect(widthAnchor).to(beIdenticalTo(view.safeAreaLayoutGuide.widthAnchor))
-                    } else {
-                        expect(widthAnchor).to(beIdenticalTo(view.widthAnchor))
-                    }
-                })
-            })
+                if #available(iOS 11.0, tvOS 11.0, *) {
+                    expect(widthAnchor).to(beIdenticalTo(view.safeAreaLayoutGuide.widthAnchor))
+                } else {
+                    expect(widthAnchor).to(beIdenticalTo(view.widthAnchor))
+                }
+            }
+        }
 
-            describe(".safeAreaHeightAnchor", {
-                it("should return the height anchor", closure: {
-                    let heightAnchor = view.safeAreaHeightAnchor
+        describe(".safeAreaHeightAnchor") {
+            it("should return the height anchor") {
+                let heightAnchor = view.safeAreaHeightAnchor
 
-                    if #available(iOS 11.0, tvOS 11.0, *) {
-                        expect(heightAnchor).to(beIdenticalTo(view.safeAreaLayoutGuide.heightAnchor))
-                    } else {
-                        expect(heightAnchor).to(beIdenticalTo(view.heightAnchor))
-                    }
-                })
-            })
+                if #available(iOS 11.0, tvOS 11.0, *) {
+                    expect(heightAnchor).to(beIdenticalTo(view.safeAreaLayoutGuide.heightAnchor))
+                } else {
+                    expect(heightAnchor).to(beIdenticalTo(view.heightAnchor))
+                }
+            }
+        }
 
-            describe(".safeAreaCenterXAnchor", {
-                it("should return the horizontal center anchor", closure: {
-                    let centerXAnchor = view.safeAreaCenterXAnchor
+        describe(".safeAreaCenterXAnchor") {
+            it("should return the horizontal center anchor") {
+                let centerXAnchor = view.safeAreaCenterXAnchor
 
-                    if #available(iOS 11.0, tvOS 11.0, *) {
-                        expect(centerXAnchor).to(beIdenticalTo(view.safeAreaLayoutGuide.centerXAnchor))
-                    } else {
-                        expect(centerXAnchor).to(beIdenticalTo(view.centerXAnchor))
-                    }
-                })
-            })
+                if #available(iOS 11.0, tvOS 11.0, *) {
+                    expect(centerXAnchor).to(beIdenticalTo(view.safeAreaLayoutGuide.centerXAnchor))
+                } else {
+                    expect(centerXAnchor).to(beIdenticalTo(view.centerXAnchor))
+                }
+            }
+        }
 
-            describe(".safeAreaCenterYAnchor", {
-                it("should return the vertical center anchor", closure: {
-                    let centerYAnchor = view.safeAreaCenterYAnchor
+        describe(".safeAreaCenterYAnchor") {
+            it("should return the vertical center anchor") {
+                let centerYAnchor = view.safeAreaCenterYAnchor
 
-                    if #available(iOS 11.0, tvOS 11.0, *) {
-                        expect(centerYAnchor).to(beIdenticalTo(view.safeAreaLayoutGuide.centerYAnchor))
-                    } else {
-                        expect(centerYAnchor).to(beIdenticalTo(view.centerYAnchor))
-                    }
-                })
-            })
-        })
+                if #available(iOS 11.0, tvOS 11.0, *) {
+                    expect(centerYAnchor).to(beIdenticalTo(view.safeAreaLayoutGuide.centerYAnchor))
+                } else {
+                    expect(centerYAnchor).to(beIdenticalTo(view.centerYAnchor))
+                }
+            }
+        }
     }
 }

--- a/AurorKitTests/Extensions/UIViewShadowExtensionTests.swift
+++ b/AurorKitTests/Extensions/UIViewShadowExtensionTests.swift
@@ -1,0 +1,59 @@
+//
+//  UIViewShadowExtensionTests.swift
+//  AurorKit
+//
+//  Created by Almaz Ibragimov on 13/02/2019.
+//  Copyright © 2019 Aurors. All rights reserved.
+//
+
+import UIKit
+
+import Quick
+import Nimble
+
+@testable import AurorKit
+
+class UIViewShadowExtensionTests: QuickSpec {
+
+    // MARK: - Instance Methods
+
+    override func spec() {
+        var view: UIView!
+
+        beforeEach {
+            view = UIView()
+        }
+
+        describe(".border") {
+            it("should return an empty shadow") {
+                expect(view.shadow.offset).to(equal(UIView.Shadow.empty.offset))
+                expect(view.shadow.radius).to(equal(UIView.Shadow.empty.radius))
+                expect(view.shadow.color).to(equalColor(UIView.Shadow.empty.color))
+                expect(view.shadow.opacity).to(equal(UIView.Shadow.empty.opacity))
+                expect(view.shadow.shouldRasterize).to(equal(UIView.Shadow.empty.shouldRasterize))
+            }
+
+            it("should return the correct shadow") {
+                expect(view.shadow.offset).to(equal(view.layer.shadowOffset))
+                expect(view.shadow.radius).to(equal(view.layer.shadowRadius))
+                expect(view.shadow.color?.cgColor).to(equal(view.layer.shadowColor))
+                expect(view.shadow.opacity).to(equal(view.layer.shadowOpacity))
+                expect(view.shadow.shouldRasterize).to(equal(view.layer.shouldRasterize))
+            }
+
+            it("should set shadow properly") {
+                view.border = UIView.Border(width: 1.23, color: UIColor(red: 0.12, green: 0.34, blue: 0.56))
+
+                expect(view.layer.borderWidth).to(equal(1.23))
+                expect(view.layer.borderColor).to(equal(UIColor(red: 0.12, green: 0.34, blue: 0.56).cgColor))
+            }
+
+            it("should set shadow properly") {
+                view.border = UIView.Border(width: 0.0, color: nil)
+
+                expect(view.layer.borderWidth).to(equal(0.0))
+                expect(view.layer.borderColor).to(beNil())
+            }
+        }
+    }
+}

--- a/AurorKitTests/Extensions/UIViewShadowExtensionTests.swift
+++ b/AurorKitTests/Extensions/UIViewShadowExtensionTests.swift
@@ -42,17 +42,31 @@ class UIViewShadowExtensionTests: QuickSpec {
             }
 
             it("should set shadow properly") {
-                view.border = UIView.Border(width: 1.23, color: UIColor(red: 0.12, green: 0.34, blue: 0.56))
+                view.shadow = UIView.Shadow(offset: CGSize(width: 1.23, height: 4.56),
+                                            radius: 3.21,
+                                            color: UIColor(red: 0.12, green: 0.34, blue: 0.56),
+                                            opacity: 0.789,
+                                            shouldRasterize: true)
 
-                expect(view.layer.borderWidth).to(equal(1.23))
-                expect(view.layer.borderColor).to(equal(UIColor(red: 0.12, green: 0.34, blue: 0.56).cgColor))
+                expect(view.layer.shadowOffset).to(equal(CGSize(width: 1.23, height: 4.56)))
+                expect(view.layer.shadowRadius).to(equal(3.21))
+                expect(view.layer.shadowColor).to(equal(UIColor(red: 0.12, green: 0.34, blue: 0.56).cgColor))
+                expect(view.layer.shadowOpacity).to(equal(0.789))
+                expect(view.layer.shouldRasterize).to(equal(true))
             }
 
             it("should set shadow properly") {
-                view.border = UIView.Border(width: 0.0, color: nil)
+                view.shadow = UIView.Shadow(offset: CGSize.zero,
+                                            radius: 0.0,
+                                            color: nil,
+                                            opacity: 0.0,
+                                            shouldRasterize: false)
 
-                expect(view.layer.borderWidth).to(equal(0.0))
-                expect(view.layer.borderColor).to(beNil())
+                expect(view.layer.shadowOffset).to(equal(CGSize.zero))
+                expect(view.layer.shadowRadius).to(equal(0.0))
+                expect(view.layer.shadowColor).to(beNil())
+                expect(view.layer.shadowOpacity).to(equal(0.0))
+                expect(view.layer.shouldRasterize).to(equal(false))
             }
         }
     }

--- a/AurorKitTests/Extensions/UIWindowExtensionTests.swift
+++ b/AurorKitTests/Extensions/UIWindowExtensionTests.swift
@@ -18,46 +18,48 @@ class UIWindowExtensionTests: QuickSpec {
     // MARK: - Instance Methods
 
     override func spec() {
-        var rootViewController: UIViewController!
-        var modalViewController: UIViewController!
-
         var window: UIWindow!
 
-        beforeEach({
-            rootViewController = UITabBarController()
-            modalViewController = UIViewController()
-
+        beforeEach {
             window = UIWindow(frame: UIScreen.main.bounds)
-        })
 
-        context("Instance Properties", {
-            describe(".topViewController", {
-                it("should return nil", closure: {
+            window.isHidden = false
+        }
+
+        describe(".topViewController") {
+            context("when window has no root view controller") {
+                it("should return nil") {
                     expect(window.topViewController).to(beNil())
-                })
+                }
+            }
 
-                it("should return root view controller", closure: {
+            context("when window has root view controller") {
+                var rootViewController: UIViewController!
+
+                beforeEach {
+                    rootViewController = UIViewController()
+
                     window.rootViewController = rootViewController
+                }
 
+                it("should return root view controller") {
                     expect(window.topViewController).to(beIdenticalTo(rootViewController))
-                })
+                }
 
-                it("should return modal view controller", closure: {
-                    window.rootViewController = rootViewController
+                context("when modal view controller is presented") {
+                    var modalViewController: UIViewController!
 
-                    rootViewController.present(modalViewController, animated: true)
+                    beforeEach {
+                        modalViewController = UIViewController()
 
-                    expect(window.topViewController).toEventually(beIdenticalTo(rootViewController))
-                })
+                        rootViewController.present(modalViewController, animated: true)
+                    }
 
-                it("should return modal view controller", closure: {
-                    window.rootViewController = rootViewController
-
-                    rootViewController.present(modalViewController, animated: false)
-
-                    expect(window.topViewController).toEventually(beIdenticalTo(rootViewController))
-                })
-            })
-        })
+                    it("should return first modal view controller") {
+                        expect(window.topViewController).toEventually(beIdenticalTo(modalViewController))
+                    }
+                }
+            }
+        }
     }
 }

--- a/AurorKitTests/Matchers.swift
+++ b/AurorKitTests/Matchers.swift
@@ -1,0 +1,59 @@
+//
+//  Matchers.swift
+//  AurorKit
+//
+//  Created by Almaz Ibragimov on 13/02/2019.
+//  Copyright © 2019 Aurors. All rights reserved.
+//
+
+import UIKit
+
+import Quick
+import Nimble
+
+func equalColor(_ expectedColor: UIColor?) -> Predicate<UIColor> {
+    return Predicate.define("equal color <\(stringify(expectedColor))>") { actualExpression, message in
+        let color = try actualExpression.evaluate()
+
+        switch (expectedColor, color) {
+        case (nil, _?):
+            return PredicateResult(status: .fail, message: message.appendedBeNilHint())
+
+        case (nil, nil), (_, nil):
+            return PredicateResult(status: .fail, message: message)
+
+        case let (expectedColor?, color?):
+            var red: CGFloat = 0
+            var green: CGFloat = 0
+            var blue: CGFloat = 0
+            var alpha: CGFloat = 0
+
+            color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+            var expectedRed: CGFloat = 0
+            var expectedGreen: CGFloat = 0
+            var expectedBlue: CGFloat = 0
+            var expectedAlpha: CGFloat = 0
+
+            expectedColor.getRed(&expectedRed, green: &expectedGreen, blue: &expectedBlue, alpha: &expectedAlpha)
+
+            guard Int(red * 255.0) == Int(expectedRed * 255.0) else {
+                return PredicateResult(bool: false, message: message)
+            }
+
+            guard Int(green * 255.0) == Int(expectedGreen * 255.0) else {
+                return PredicateResult(bool: false, message: message)
+            }
+
+            guard Int(blue * 255.0) == Int(expectedBlue * 255.0) else {
+                return PredicateResult(bool: false, message: message)
+            }
+
+            guard Int(alpha * 255.0) == Int(expectedAlpha * 255.0) else {
+                return PredicateResult(bool: false, message: message)
+            }
+
+            return PredicateResult(bool: true, message: message)
+        }
+    }
+}

--- a/AurorKitTests/Matchers.swift
+++ b/AurorKitTests/Matchers.swift
@@ -23,17 +23,17 @@ func equalColor(_ expectedColor: UIColor?) -> Predicate<UIColor> {
             return PredicateResult(status: .fail, message: message)
 
         case let (expectedColor?, color?):
-            var red: CGFloat = 0
-            var green: CGFloat = 0
-            var blue: CGFloat = 0
-            var alpha: CGFloat = 0
+            var red: CGFloat = 0.0
+            var green: CGFloat = 0.0
+            var blue: CGFloat = 0.0
+            var alpha: CGFloat = 0.0
 
             color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 
-            var expectedRed: CGFloat = 0
-            var expectedGreen: CGFloat = 0
-            var expectedBlue: CGFloat = 0
-            var expectedAlpha: CGFloat = 0
+            var expectedRed: CGFloat = 0.0
+            var expectedGreen: CGFloat = 0.0
+            var expectedBlue: CGFloat = 0.0
+            var expectedAlpha: CGFloat = 0.0
 
             expectedColor.getRed(&expectedRed, green: &expectedGreen, blue: &expectedBlue, alpha: &expectedAlpha)
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - Nimble (7.3.2)
-  - Quick (1.3.2)
+  - Nimble (7.3.4)
+  - Quick (1.3.4)
 
 DEPENDENCIES:
   - Nimble
@@ -12,8 +12,8 @@ SPEC REPOS:
     - Quick
 
 SPEC CHECKSUMS:
-  Nimble: 5e94a8cacb355943c6c87198035dc4adbb0f10e4
-  Quick: 2623cb30d7a7f41ca62f684f679586558f483d46
+  Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
+  Quick: f4f7f063c524394c73ed93ac70983c609805d481
 
 PODFILE CHECKSUM: beca08253c9b8099ce2a3ef38677505115e0073e
 


### PR DESCRIPTION
- Added the `Comparable` protocol extension with methods for clamping values
- Added methods to convert `UIColor` instance to various hex-representations
- Added initializers to create `UIColor` instance from various hex-representations
- Added `alignmentRect` property to the `UIImage` extension
- Added the `UIView` extension to combine border parameters in a single property (`border`)
- Added the `UIView` extension to combine shadow parameters in a single property (`shadow`)
- Added the `UIViewController` extension with `isVisible` property
- Redesigned all existing tests and added new ones
- Added Nimble matcher to compare UIColor instances
- Disabled SwiftLint `file_name` rule